### PR TITLE
Error handling for get cloud image calls

### DIFF
--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/Cluster.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/Cluster.java
@@ -73,5 +73,4 @@ public class Cluster {
     @Column(name = "ENV", columnDefinition = "text", length = 65535)
     @JsonProperty("env-var-script")
     private String envVars;
-
 }

--- a/sal-service/src/main/java/org/ow2/proactive/sal/service/service/CloudService.java
+++ b/sal-service/src/main/java/org/ow2/proactive/sal/service/service/CloudService.java
@@ -113,7 +113,7 @@ public class CloudService {
             repositoryService.saveCredentials(credentials);
             newCloud.setCredentials(credentials);
 
-            String dummyInfraName = "iamadummy" + newCloud.getCloudProviderName();
+            String dummyInfraName = "iamadummy" + newCloud.getCloudProviderName() + "_" + newCloud.getCloudId();
             connectorIaasGateway.defineInfrastructure(dummyInfraName, newCloud, "");
             newCloud.setDummyInfrastructureName(dummyInfraName);
 
@@ -348,7 +348,7 @@ public class CloudService {
      * This function returns the list of all available images related to a registered cloud
      * @param sessionId A valid session id
      * @param cloudId A valid cloud identifier
-     * @return A list of available images
+     * @return A list of available images for a registered cloud
      */
     public List<Image> getCloudImages(String sessionId, String cloudId) throws NotConnectedException {
         List<Image> allImages = getAllCloudImages(sessionId);
@@ -362,11 +362,11 @@ public class CloudService {
                                               .collect(Collectors.toList());
             LOGGER.debug("Filtering images related to cloud ID \'" + cloudId + "\'.");
             allImages.stream().filter(blaTest -> imagesIDs.contains(blaTest.getId())).forEach(filteredImages::add);
-            return filteredImages;
         } else {
-            LOGGER.warn("Cloud ID \'" + cloudId + "\' is not found in DB. getAllCloudImages() will return all images.");
-            return allImages;
+            LOGGER.warn("Cloud ID \'" + cloudId + "\' is not found in SAL DB.");
+            // return allImages; // -> this was reason why we got images from other clouds
         }
+        return filteredImages;
     }
 
     /**

--- a/sal-service/src/main/java/org/ow2/proactive/sal/service/service/infrastructure/PAConnectorIaasGateway.java
+++ b/sal-service/src/main/java/org/ow2/proactive/sal/service/service/infrastructure/PAConnectorIaasGateway.java
@@ -39,7 +39,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.http.client.utils.URIBuilder;
 import org.jboss.netty.handler.codec.http.HttpMethod;
-import org.jclouds.rest.AuthorizationException;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.ow2.proactive.sal.model.PACloud;
@@ -107,11 +106,6 @@ public class PAConnectorIaasGateway {
             } else {
                 LOGGER.info("Images retrieved for cloud {}. Images: {}", nodeSourceName, images);
             }
-        } catch (AuthorizationException e) {
-            LOGGER.error("Authorization error while retrieving images for cloud {}: {}",
-                         nodeSourceName,
-                         e.getMessage());
-            throw e;
         } catch (IOException e) {
             LOGGER.error("An error occurred while retrieving images for cloud {}: {}",
                          nodeSourceName,


### PR DESCRIPTION
What is resolved:
-> when the images can't be retrived the error is logged and send back to caller - previously it was retrurning empty set or even images from another clouds
-> cloud infrastructures are now created with unique infrastructure ID when IAAS connector is called to create them

Expected behavior with problematic clouds:
1. Add cloud -> retrun 0 if infrastructure is added
2. Get Cloud Images -> now it gives the error if there is problem with retriving the images  because  cloud is not existing, cloud infrastracture is not authorized to retrive images or the cardentials are wrong
3. Get Node Candidates -> retrurns empty set of nodes in case of problems