### PR TITLE
Wait for master kubeCommand assigment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,4 @@ gradle-app.setting
 
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties
+!/docker/docker-compose.yaml

--- a/sal-service/src/main/resources/wait_for_master.groovy
+++ b/sal-service/src/main/resources/wait_for_master.groovy
@@ -37,23 +37,51 @@ def checkIPFromServers() {
     println "Unable to retrieve the public IP from any server."
 }
 
-def getKubeToken(){
-    def soutToken = new StringBuilder(), serrToken = new StringBuilder()
-    // def proc = "kubeadm token create \"$(kubeadm token generate)\" --print-join-command --ttl=1h >  /tmp/join_call.txt".execute()
-    def procToken = "kubeadm token generate".execute()
-    procToken.consumeProcessOutput(soutToken, serrToken)
-    procToken.waitForOrKill(1000)
-    println "out> ${soutToken}\nerr> ${serrToken}"
+def getKubeToken(int retryCount = 5, int retryDelay = 1000) {
+    for (int attempt = 1; attempt <= retryCount; attempt++) {
+        println "Attempt ${attempt} of ${retryCount}"
 
-    def soutCommand = new StringBuilder(), serrCommand = new StringBuilder()
-    procCommand="kubeadm token create ${soutToken} --print-join-command --ttl=1h".execute()
-    procCommand.consumeProcessOutput(soutCommand, serrCommand)
-    procCommand.waitForOrKill(1000)
-    println "out> ${soutCommand}\nerr> ${serrCommand}"
-    variables.put("kubeCommand", soutCommand)
+        // Generate token
+        def soutToken = new StringBuilder(), serrToken = new StringBuilder()
+        def procToken = "kubeadm token generate".execute()
+        procToken.consumeProcessOutput(soutToken, serrToken)
+        procToken.waitForOrKill(1000)
+        println "Token generation - out> ${soutToken}\nerr> ${serrToken}"
+
+        if (serrToken.toString().trim()) {
+            println "Error generating token: ${serrToken}"
+            sleep(retryDelay)
+            continue
+        }
+
+        def token = soutToken.toString().trim()
+
+        // Create join command
+        def soutCommand = new StringBuilder(), serrCommand = new StringBuilder()
+        def procCommand = "kubeadm token create ${token} --print-join-command --ttl=1h".execute()
+        procCommand.consumeProcessOutput(soutCommand, serrCommand)
+        procCommand.waitForOrKill(1000)
+        println "Join command generation - out> ${soutCommand}\nerr> ${serrCommand}"
+
+        if (serrCommand.toString().trim() || soutCommand.toString().trim().isEmpty()) {
+            println "Error generating join command: ${serrCommand}"
+            sleep(retryDelay)
+            continue
+        }
+
+        // Store the join command and return
+        def joinCommand = soutCommand.toString().trim()
+        variables.put("kubeCommand", joinCommand)
+        println "kubeCommand stored: ${joinCommand}"
+        return
+    }
+
+    println "Failed to generate kube join command after ${retryCount} attempts."
 }
 
-getKubeToken()
+// Call the function with the desired number of retries
+getKubeToken(5, 1000)  // Retry 3 times with a delay of 1000ms (1 second) between attempts
+
 
 // Call the function to check the IP
 result = checkIPFromServers()


### PR DESCRIPTION
This is a change in workflow for the worker node on waiting for the master script, It is now retrying 5 times to `getKubeToken` with a time gap. Also, the script is enhanced to capture if there are errors in generating the token or join command, they are logged, and the script proceeds to the next attempt.
If the join command is successfully generated, it is stored in the variables map, and the function exits.
If the script fails to generate the join command after the specified number of attempts, it logs a failure message.

Bug report: https://trello.com/c/St6y2b8j