### PR TITLE
sal-common refactoring

### DIFF
--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/AbstractNode.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/AbstractNode.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 
+
 @Getter
 @Setter
 @MappedSuperclass
@@ -21,6 +22,7 @@ public abstract class AbstractNode implements Node {
 
     // JSON field constants
     public static final String JSON_ID = "id";
+
     public static final String JSON_NODE_CANDIDATE = "nodeCandidate";
 
     @Id

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/AbstractNode.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/AbstractNode.java
@@ -14,19 +14,23 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 
-
 @Getter
 @Setter
 @MappedSuperclass
 public abstract class AbstractNode implements Node {
 
+    // JSON field constants
+    public static final String JSON_ID = "id";
+    public static final String JSON_NODE_CANDIDATE = "nodeCandidate";
+
     @Id
     @GeneratedValue(generator = "system-uuid")
     @GenericGenerator(name = "system-uuid", strategy = "uuid")
     @Column(name = "ID")
-    @JsonProperty("id")
+    @JsonProperty(JSON_ID)
     protected String id = null;
 
     @OneToOne(fetch = FetchType.EAGER, cascade = CascadeType.REFRESH)
+    @JsonProperty(JSON_NODE_CANDIDATE)
     protected NodeCandidate nodeCandidate = null;
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/AttributeRequirement.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/AttributeRequirement.java
@@ -5,11 +5,10 @@
  */
 package org.ow2.proactive.sal.model;
 
-import java.util.Objects;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -19,23 +18,30 @@ import lombok.Setter;
  */
 @Getter
 @Setter
+@EqualsAndHashCode(callSuper = true)
 @JsonTypeName(value = "AttributeRequirement")
 public class AttributeRequirement extends Requirement {
-    @JsonProperty("requirementClass")
+
+    // JSON property constants
+    public static final String JSON_REQUIREMENT_CLASS = "requirementClass";
+
+    public static final String JSON_REQUIREMENT_ATTRIBUTE = "requirementAttribute";
+
+    public static final String JSON_REQUIREMENT_OPERATOR = "requirementOperator";
+
+    public static final String JSON_VALUE = "value";
+
+    @JsonProperty(JSON_REQUIREMENT_CLASS)
     private String requirementClass;
 
-    @JsonProperty("requirementAttribute")
+    @JsonProperty(JSON_REQUIREMENT_ATTRIBUTE)
     private String requirementAttribute;
 
-    @JsonProperty("requirementOperator")
+    @JsonProperty(JSON_REQUIREMENT_OPERATOR)
     private RequirementOperator requirementOperator;
 
-    @JsonProperty("value")
+    @JsonProperty(JSON_VALUE)
     private String value;
-
-    public AttributeRequirement() {
-        this.type = RequirementType.ATTRIBUTE;
-    }
 
     public AttributeRequirement(String requirementClass, String requirementAttribute,
             RequirementOperator requirementOperator, String value) {
@@ -47,34 +53,27 @@ public class AttributeRequirement extends Requirement {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        AttributeRequirement attributeRequirement = (AttributeRequirement) o;
-        return Objects.equals(this.requirementClass, attributeRequirement.requirementClass) &&
-               Objects.equals(this.requirementAttribute, attributeRequirement.requirementAttribute) &&
-               Objects.equals(this.requirementOperator, attributeRequirement.requirementOperator) &&
-               Objects.equals(this.value, attributeRequirement.value) && super.equals(o);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(requirementClass, requirementAttribute, requirementOperator, value, super.hashCode());
-    }
-
-    @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("class AttributeRequirement {\n");
-        sb.append("    ").append(toIndentedString(super.toString())).append("\n");
-        sb.append("    requirementClass: ").append(toIndentedString(requirementClass)).append("\n");
-        sb.append("    requirementAttribute: ").append(toIndentedString(requirementAttribute)).append("\n");
-        sb.append("    requirementOperator: ").append(toIndentedString(requirementOperator)).append("\n");
-        sb.append("    value: ").append(toIndentedString(value)).append("\n");
+
+        sb.append("    ").append(super.toString()).append("\n");
+        sb.append("    ")
+          .append(JSON_REQUIREMENT_CLASS)
+          .append(": ")
+          .append(toIndentedString(requirementClass))
+          .append("\n");
+        sb.append("    ")
+          .append(JSON_REQUIREMENT_ATTRIBUTE)
+          .append(": ")
+          .append(toIndentedString(requirementAttribute))
+          .append("\n");
+        sb.append("    ")
+          .append(JSON_REQUIREMENT_OPERATOR)
+          .append(": ")
+          .append(toIndentedString(requirementOperator))
+          .append("\n");
+        sb.append("    ").append(JSON_VALUE).append(": ").append(toIndentedString(value)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/AttributeRequirement.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/AttributeRequirement.java
@@ -5,6 +5,11 @@
  */
 package org.ow2.proactive.sal.model;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.ow2.proactive.sal.util.ModelUtils;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
@@ -19,8 +24,10 @@ import lombok.Setter;
 @Getter
 @Setter
 @EqualsAndHashCode(callSuper = true)
-@JsonTypeName(value = "AttributeRequirement")
+@JsonTypeName(value = AttributeRequirement.CLASS_NAME)
 public class AttributeRequirement extends Requirement {
+    // Define class name constant for reuse
+    public static final String CLASS_NAME = "AttributeRequirement";
 
     // JSON property constants
     public static final String JSON_REQUIREMENT_CLASS = "requirementClass";
@@ -43,6 +50,10 @@ public class AttributeRequirement extends Requirement {
     @JsonProperty(JSON_VALUE)
     private String value;
 
+    public AttributeRequirement() {
+        this.type = RequirementType.ATTRIBUTE;
+    }
+
     public AttributeRequirement(String requirementClass, String requirementAttribute,
             RequirementOperator requirementOperator, String value) {
         this.type = RequirementType.ATTRIBUTE;
@@ -52,40 +63,29 @@ public class AttributeRequirement extends Requirement {
         this.value = value;
     }
 
+    /**
+     * Custom toString() method for the AttributeRequirement class to format the output
+     * This method creates a formatted string representation of the AttributeRequirement object.
+     * It uses a map of field names (represented as JSON constants) and their corresponding values
+     * to build a human-readable string. The method leverages the {@link ModelUtils#buildToString}
+     * utility method to generate the string, ensuring that all fields are included with proper formatting.
+     *
+     * @return A formatted string representation of the AttributeRequirement object, with each field on a new line.
+     */
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("class AttributeRequirement {\n");
+        Map<String, Object> fields = new LinkedHashMap<>();
+        fields.put(JSON_REQUIREMENT_CLASS, requirementClass);
+        fields.put(JSON_REQUIREMENT_ATTRIBUTE, requirementAttribute);
+        fields.put(JSON_REQUIREMENT_OPERATOR, requirementOperator);
+        fields.put(JSON_VALUE, value);
 
-        sb.append("    ").append(super.toString()).append("\n");
-        sb.append("    ")
-          .append(JSON_REQUIREMENT_CLASS)
-          .append(": ")
-          .append(toIndentedString(requirementClass))
-          .append("\n");
-        sb.append("    ")
-          .append(JSON_REQUIREMENT_ATTRIBUTE)
-          .append(": ")
-          .append(toIndentedString(requirementAttribute))
-          .append("\n");
-        sb.append("    ")
-          .append(JSON_REQUIREMENT_OPERATOR)
-          .append(": ")
-          .append(toIndentedString(requirementOperator))
-          .append("\n");
-        sb.append("    ").append(JSON_VALUE).append(": ").append(toIndentedString(value)).append("\n");
-        sb.append("}");
-        return sb.toString();
-    }
+        // Include the parent class fields as well
+        String parentString = super.toString();
+        Map<String, Object> parentFields = new LinkedHashMap<>();
+        parentFields.put("type", type);
+        fields.putAll(parentFields);
 
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
+        return ModelUtils.buildToString(CLASS_NAME, fields);
     }
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/Cloud.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/Cloud.java
@@ -6,10 +6,12 @@
 package org.ow2.proactive.sal.model;
 
 import java.io.Serializable;
-import java.util.Locale;
-import java.util.Objects;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import javax.persistence.*;
+
+import org.ow2.proactive.sal.util.ModelUtils;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -27,9 +29,9 @@ import lombok.Setter;
  */
 @Getter
 @Setter
+@EqualsAndHashCode
 @NoArgsConstructor
 @AllArgsConstructor
-@EqualsAndHashCode
 @Entity
 @Table(name = "CLOUD")
 public class Cloud implements Serializable {
@@ -58,7 +60,6 @@ public class Cloud implements Serializable {
 
     @Column(name = "ENDPOINT")
     @JsonProperty(JSON_ENDPOINT)
-    @EqualsAndHashCode.Include
     private String endpoint = null;
 
     @Column(name = "CLOUD_TYPE")
@@ -98,7 +99,7 @@ public class Cloud implements Serializable {
         OK("OK"),
         ERROR("ERROR");
 
-        private String value;
+        private final String value;
 
         StateEnum(String value) {
             this.value = value;
@@ -107,13 +108,13 @@ public class Cloud implements Serializable {
         @Override
         @JsonValue
         public String toString() {
-            return String.valueOf(value);
+            return value;
         }
 
         @JsonCreator
         public static StateEnum fromValue(String text) {
             for (StateEnum b : StateEnum.values()) {
-                if (String.valueOf(b.value).equals(text.toUpperCase(Locale.ROOT))) {
+                if (b.value.equalsIgnoreCase(text)) {
                     return b;
                 }
             }
@@ -122,52 +123,19 @@ public class Cloud implements Serializable {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Cloud cloud = (Cloud) o;
-        return Objects.equals(this.endpoint, cloud.endpoint) && Objects.equals(this.cloudType, cloud.cloudType) &&
-               Objects.equals(this.api, cloud.api) && Objects.equals(this.credential, cloud.credential) &&
-               Objects.equals(this.cloudConfiguration, cloud.cloudConfiguration) && Objects.equals(this.id, cloud.id) &&
-               Objects.equals(this.owner, cloud.owner) && Objects.equals(this.state, cloud.state) &&
-               Objects.equals(this.diagnostic, cloud.diagnostic);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(endpoint, cloudType, api, credential, cloudConfiguration, id, owner, state, diagnostic);
-    }
-
-    @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("class Cloud {\n");
+        Map<String, Object> fields = new LinkedHashMap<>();
+        fields.put(JSON_ID, id);
+        fields.put(JSON_ENDPOINT, endpoint);
+        fields.put(JSON_CLOUD_TYPE, cloudType);
+        fields.put(JSON_API, api);
+        fields.put(JSON_CREDENTIAL, credential);
+        fields.put(JSON_CLOUD_CONFIGURATION, cloudConfiguration);
+        fields.put(JSON_OWNER, owner);
+        fields.put(JSON_STATE, state);
+        fields.put(JSON_DIAGNOSTIC, diagnostic);
 
-        sb.append("    endpoint: ").append(toIndentedString(endpoint)).append("\n");
-        sb.append("    cloudType: ").append(toIndentedString(cloudType)).append("\n");
-        sb.append("    api: ").append(toIndentedString(api)).append("\n");
-        sb.append("    credential: ").append(toIndentedString(credential)).append("\n");
-        sb.append("    cloudConfiguration: ").append(toIndentedString(cloudConfiguration)).append("\n");
-        sb.append("    id: ").append(toIndentedString(id)).append("\n");
-        sb.append("    owner: ").append(toIndentedString(owner)).append("\n");
-        sb.append("    state: ").append(toIndentedString(state)).append("\n");
-        sb.append("    diagnostic: ").append(toIndentedString(diagnostic)).append("\n");
-        sb.append("}");
-        return sb.toString();
+        return ModelUtils.buildToString(Cloud.class.getSimpleName(), fields);
     }
 
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
-    }
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/Cloud.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/Cloud.java
@@ -16,53 +16,86 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 
 /**
  * Representation of a cloud used by Cloudiator
  */
-@AllArgsConstructor
+@Getter
+@Setter
 @NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
 @Entity
 @Table(name = "CLOUD")
 public class Cloud implements Serializable {
+    public static final String JSON_ID = "id";
+
+    public static final String JSON_ENDPOINT = "endpoint";
+
+    public static final String JSON_CLOUD_TYPE = "cloudType";
+
+    public static final String JSON_API = "api";
+
+    public static final String JSON_CREDENTIAL = "credential";
+
+    public static final String JSON_CLOUD_CONFIGURATION = "cloudConfiguration";
+
+    public static final String JSON_OWNER = "owner";
+
+    public static final String JSON_STATE = "state";
+
+    public static final String JSON_DIAGNOSTIC = "diagnostic";
+
     @Id
     @Column(name = "ID")
-    @JsonProperty("id")
+    @JsonProperty(JSON_ID)
     private String id = null;
 
     @Column(name = "ENDPOINT")
-    @JsonProperty("endpoint")
+    @JsonProperty(JSON_ENDPOINT)
+    @EqualsAndHashCode.Include
     private String endpoint = null;
 
     @Column(name = "CLOUD_TYPE")
     @Enumerated(EnumType.STRING)
-    @JsonProperty("cloudType")
+    @JsonProperty(JSON_CLOUD_TYPE)
     private CloudType cloudType = null;
 
     @Embedded
-    @JsonProperty("api")
+    @JsonProperty(JSON_API)
     private Api api = null;
 
     @Embedded
-    @JsonProperty("credential")
+    @JsonProperty(JSON_CREDENTIAL)
     private CloudCredential credential = null;
 
     @Embedded
-    @JsonProperty("cloudConfiguration")
+    @JsonProperty(JSON_CLOUD_CONFIGURATION)
     private CloudConfiguration cloudConfiguration = null;
 
     @Column(name = "OWNER")
-    @JsonProperty("owner")
+    @JsonProperty(JSON_OWNER)
     private String owner = null;
+
+    @Column(name = "STATE")
+    @Enumerated(EnumType.STRING)
+    @JsonProperty(JSON_STATE)
+    private StateEnum state = null;
+
+    @Column(name = "DIAGNOSTIC")
+    @JsonProperty(JSON_DIAGNOSTIC)
+    private String diagnostic = null;
 
     /**
      * State of the cloud
      */
     public enum StateEnum {
         OK("OK"),
-
         ERROR("ERROR");
 
         private String value;
@@ -86,168 +119,6 @@ public class Cloud implements Serializable {
             }
             return null;
         }
-    }
-
-    @Column(name = "STATE")
-    @Enumerated(EnumType.STRING)
-    @JsonProperty("state")
-    private StateEnum state = null;
-
-    @Column(name = "DIAGNOSTIC")
-    @JsonProperty("diagnostic")
-    private String diagnostic = null;
-
-    public Cloud endpoint(String endpoint) {
-        this.endpoint = endpoint;
-        return this;
-    }
-
-    /**
-     * URI where the api of this cloud provider can be accessed.
-     * @return endpoint
-     **/
-    public String getEndpoint() {
-        return endpoint;
-    }
-
-    public void setEndpoint(String endpoint) {
-        this.endpoint = endpoint;
-    }
-
-    public Cloud cloudType(CloudType cloudType) {
-        this.cloudType = cloudType;
-        return this;
-    }
-
-    /**
-     * Get cloudType
-     * @return cloudType
-     **/
-    public CloudType getCloudType() {
-        return cloudType;
-    }
-
-    public void setCloudType(CloudType cloudType) {
-        this.cloudType = cloudType;
-    }
-
-    public Cloud api(Api api) {
-        this.api = api;
-        return this;
-    }
-
-    /**
-     * Get api
-     * @return api
-     **/
-    public Api getApi() {
-        return api;
-    }
-
-    public void setApi(Api api) {
-        this.api = api;
-    }
-
-    public Cloud credential(CloudCredential credential) {
-        this.credential = credential;
-        return this;
-    }
-
-    /**
-     * Get credential
-     * @return credential
-     **/
-    public CloudCredential getCredential() {
-        return credential;
-    }
-
-    public void setCredential(CloudCredential credential) {
-        this.credential = credential;
-    }
-
-    public Cloud cloudConfiguration(CloudConfiguration cloudConfiguration) {
-        this.cloudConfiguration = cloudConfiguration;
-        return this;
-    }
-
-    /**
-     * Get cloudConfiguration
-     * @return cloudConfiguration
-     **/
-    public CloudConfiguration getCloudConfiguration() {
-        return cloudConfiguration;
-    }
-
-    public void setCloudConfiguration(CloudConfiguration cloudConfiguration) {
-        this.cloudConfiguration = cloudConfiguration;
-    }
-
-    public Cloud id(String id) {
-        this.id = id;
-        return this;
-    }
-
-    /**
-     * Unique identifier for the cloud
-     * @return id
-     **/
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public Cloud owner(String owner) {
-        this.owner = owner;
-        return this;
-    }
-
-    /**
-     * Id of the user owning this cloud.
-     * @return owner
-     **/
-    public String getOwner() {
-        return owner;
-    }
-
-    public void setOwner(String owner) {
-        this.owner = owner;
-    }
-
-    public Cloud state(StateEnum state) {
-        this.state = state;
-        return this;
-    }
-
-    /**
-     * State of the cloud
-     * @return state
-     **/
-    public StateEnum getState() {
-        return state;
-    }
-
-    public void setState(StateEnum state) {
-        this.state = state;
-    }
-
-    public Cloud diagnostic(String diagnostic) {
-        this.diagnostic = diagnostic;
-        return this;
-    }
-
-    /**
-     * Diagnostic information for the cloud
-     * @return diagnostic
-     **/
-    public String getDiagnostic() {
-        return diagnostic;
-    }
-
-    public void setDiagnostic(String diagnostic) {
-        this.diagnostic = diagnostic;
     }
 
     @Override

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/CloudConfiguration.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/CloudConfiguration.java
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 package org.ow2.proactive.sal.model;
 
 import java.io.Serializable;
@@ -6,14 +11,16 @@ import java.util.Map;
 
 import javax.persistence.*;
 
+import org.ow2.proactive.sal.util.ModelUtils;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.ow2.proactive.sal.util.ModelUtils; // Assuming this is the correct import for ModelUtils
+
 
 /**
  * Represents the configuration of a cloud.
@@ -23,11 +30,12 @@ import org.ow2.proactive.sal.util.ModelUtils; // Assuming this is the correct im
 @Embeddable
 @Getter
 @Setter
-@EqualsAndHashCode(of = {CloudConfiguration.JSON_NODE_GROUP, CloudConfiguration.JSON_PROPERTIES})
+@EqualsAndHashCode(of = { CloudConfiguration.JSON_NODE_GROUP, CloudConfiguration.JSON_PROPERTIES })
 public class CloudConfiguration implements Serializable {
 
     // JSON field constants
     public static final String JSON_NODE_GROUP = "nodeGroup";
+
     public static final String JSON_PROPERTIES = "properties";
 
     @Column(name = "NODE_GROUP")
@@ -52,7 +60,6 @@ public class CloudConfiguration implements Serializable {
 
         return ModelUtils.buildToString(CloudConfiguration.class.getSimpleName(), fields);
     }
-
 
     @PreRemove
     private void cleanMappedDataFirst() {

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/CloudConfiguration.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/CloudConfiguration.java
@@ -1,13 +1,8 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/.
- */
 package org.ow2.proactive.sal.model;
 
 import java.io.Serializable;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Objects;
 
 import javax.persistence.*;
 
@@ -15,97 +10,49 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
-
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import org.ow2.proactive.sal.util.ModelUtils; // Assuming this is the correct import for ModelUtils
 
 /**
- * Repesents the configuration of a cloud.
+ * Represents the configuration of a cloud.
  */
 @AllArgsConstructor
 @NoArgsConstructor
 @Embeddable
+@Getter
+@Setter
+@EqualsAndHashCode(of = {CloudConfiguration.JSON_NODE_GROUP, CloudConfiguration.JSON_PROPERTIES})
 public class CloudConfiguration implements Serializable {
+
+    // JSON field constants
+    public static final String JSON_NODE_GROUP = "nodeGroup";
+    public static final String JSON_PROPERTIES = "properties";
+
     @Column(name = "NODE_GROUP")
-    @JsonProperty("nodeGroup")
+    @JsonProperty(JSON_NODE_GROUP)
     private String nodeGroup = null;
 
     @Column(name = "PROPERTIES")
     @ElementCollection(targetClass = String.class, fetch = FetchType.EAGER)
-    @JsonProperty("properties")
+    @JsonProperty(JSON_PROPERTIES)
     private Map<String, String> properties = null;
 
-    public CloudConfiguration nodeGroup(String nodeGroup) {
-        this.nodeGroup = nodeGroup;
-        return this;
-    }
-
     /**
-     * A prefix all Cloudiator managed entities will belong to.
-     * @return nodeGroup
-     **/
-    public String getNodeGroup() {
-        return nodeGroup;
-    }
-
-    public void setNodeGroup(String nodeGroup) {
-        this.nodeGroup = nodeGroup;
-    }
-
-    public CloudConfiguration properties(Map<String, String> properties) {
-        this.properties = properties;
-        return this;
-    }
-
-    /**
-     * Configuration as key-value map.
-     * @return properties
-     **/
-    public Map<String, String> getProperties() {
-        return properties;
-    }
-
-    public void setProperties(Map<String, String> properties) {
-        this.properties = properties;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        CloudConfiguration cloudConfiguration = (CloudConfiguration) o;
-        return Objects.equals(this.nodeGroup, cloudConfiguration.nodeGroup) &&
-               Objects.equals(this.properties, cloudConfiguration.properties);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(nodeGroup, properties);
-    }
-
+     * Custom toString() method for the CloudConfiguration class using ModelUtils.
+     * This method uses {@link ModelUtils#buildToString} to generate the string representation of the object.
+     * @return A formatted string representation of the CloudConfiguration object.
+     */
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("class CloudConfiguration {\n");
+        Map<String, Object> fields = new LinkedHashMap<>();
+        fields.put(JSON_NODE_GROUP, nodeGroup);
+        fields.put(JSON_PROPERTIES, properties);
 
-        sb.append("    nodeGroup: ").append(toIndentedString(nodeGroup)).append("\n");
-        sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
-        sb.append("}");
-        return sb.toString();
+        return ModelUtils.buildToString(CloudConfiguration.class.getSimpleName(), fields);
     }
 
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
-    }
 
     @PreRemove
     private void cleanMappedDataFirst() {

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/CloudCredential.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/CloudCredential.java
@@ -6,15 +6,21 @@
 package org.ow2.proactive.sal.model;
 
 import java.io.Serializable;
-import java.util.Objects;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 
+import org.ow2.proactive.sal.util.ModelUtils;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 
 /**
@@ -23,85 +29,36 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Embeddable
+@EqualsAndHashCode
+@Getter
+@Setter
 public class CloudCredential implements Serializable {
+    public static final String JSON_USER = "user";
+
+    public static final String JSON_SECRET = "secret";
+
     @Column(name = "USER")
-    @JsonProperty("user")
+    @JsonProperty(JSON_USER)
     private String user = null;
 
     @Column(name = "SECRET")
-    @JsonProperty("secret")
+    @JsonProperty(JSON_SECRET)
     private String secret = null;
 
-    public CloudCredential user(String user) {
-        this.user = user;
-        return this;
-    }
-
     /**
-     * Username for authentication at the cloud provider's API
-     * @return user
-     **/
-    public String getUser() {
-        return user;
-    }
-
-    public void setUser(String user) {
-        this.user = user;
-    }
-
-    public CloudCredential secret(String secret) {
-        this.secret = secret;
-        return this;
-    }
-
-    /**
-     * Secret (e.g. Password) for authentication at the cloud provider's API
-     * @return secret
-     **/
-    public String getSecret() {
-        return secret;
-    }
-
-    public void setSecret(String secret) {
-        this.secret = secret;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        CloudCredential cloudCredential = (CloudCredential) o;
-        return Objects.equals(this.user, cloudCredential.user) && Objects.equals(this.secret, cloudCredential.secret);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(user, secret);
-    }
-
+     * Custom toString() method for the class to format the output.
+     * This method creates a formatted string representation of the class object.
+     * It uses a map of field names (represented as JSON constants) and their corresponding values
+     * to build a human-readable string. The method leverages the {@link ModelUtils#buildToString}
+     * utility method to generate the string, ensuring that all fields are included with proper formatting.
+     *
+     * @return A formatted string representation of the Hardware object, with each field on a new line.
+     */
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("class CloudCredential {\n");
-
-        sb.append("    user: ").append(toIndentedString(user)).append("\n");
-        sb.append("    secret: ").append(toIndentedString(secret)).append("\n");
-        sb.append("}");
-        return sb.toString();
-    }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
+        Map<String, Object> fields = new LinkedHashMap<>();
+        fields.put(JSON_USER, user);
+        fields.put(JSON_SECRET, secret);
+        return ModelUtils.buildToString(getClass().getSimpleName(), fields);
     }
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/CloudDefinition.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/CloudDefinition.java
@@ -1,8 +1,3 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/.
- */
 package org.ow2.proactive.sal.model;
 
 import java.io.Serializable;
@@ -13,9 +8,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.*;
 
-
 /**
- * Attributes defining a Cloud`
+ * Attributes defining a Cloud
  */
 @AllArgsConstructor
 @NoArgsConstructor
@@ -24,41 +18,55 @@ import lombok.*;
 @ToString(callSuper = true)
 public class CloudDefinition implements Serializable {
 
-    @JsonProperty("cloudId")
+    // JSON field constants
+    public static final String JSON_CLOUD_ID = "cloudId";
+    public static final String JSON_CLOUD_PROVIDER_NAME = "cloudProviderName";
+    public static final String JSON_CLOUD_TYPE = "cloudType";
+    public static final String JSON_SECURITY_GROUP = "securityGroup";
+    public static final String JSON_SUBNET = "subnet";
+    public static final String JSON_SSH_CREDENTIALS = "sshCredentials";
+    public static final String JSON_ENDPOINT = "endpoint";
+    public static final String JSON_SCOPE = "scope";
+    public static final String JSON_IDENTITY_VERSION = "identityVersion";
+    public static final String JSON_DEFAULT_NETWORK = "defaultNetwork";
+    public static final String JSON_CREDENTIALS = "credentials";
+    public static final String JSON_BLACKLIST = "blacklist";
+
+    @JsonProperty(JSON_CLOUD_ID)
     private String cloudId = null;
 
-    @JsonProperty("cloudProviderName")
+    @JsonProperty(JSON_CLOUD_PROVIDER_NAME)
     private CloudProviderType cloudProvider = null;
 
-    @JsonProperty("cloudType")
+    @JsonProperty(JSON_CLOUD_TYPE)
     private CloudType cloudType = null;
 
-    @JsonProperty("securityGroup")
+    @JsonProperty(JSON_SECURITY_GROUP)
     private String securityGroup = null;
 
-    @JsonProperty("subnet")
+    @JsonProperty(JSON_SUBNET)
     private String subnet = null;
 
     @Embedded
-    @JsonProperty("sshCredentials")
+    @JsonProperty(JSON_SSH_CREDENTIALS)
     private SSHCredentials sshCredentials = null;
 
-    @JsonProperty("endpoint")
+    @JsonProperty(JSON_ENDPOINT)
     private String endpoint = null;
 
     @Embedded
-    @JsonProperty("scope")
+    @JsonProperty(JSON_SCOPE)
     private Scope scope = null;
 
-    @JsonProperty("identityVersion")
+    @JsonProperty(JSON_IDENTITY_VERSION)
     private String identityVersion;
 
-    @JsonProperty("defaultNetwork")
+    @JsonProperty(JSON_DEFAULT_NETWORK)
     private String defaultNetwork;
 
-    @JsonProperty("credentials")
+    @JsonProperty(JSON_CREDENTIALS)
     private Credential credentials;
 
-    @JsonProperty("blacklist")
+    @JsonProperty(JSON_BLACKLIST)
     private String blacklist;
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/CloudDefinition.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/CloudDefinition.java
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 package org.ow2.proactive.sal.model;
 
 import java.io.Serializable;
@@ -7,6 +12,7 @@ import javax.persistence.Embedded;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.*;
+
 
 /**
  * Attributes defining a Cloud
@@ -20,16 +26,27 @@ public class CloudDefinition implements Serializable {
 
     // JSON field constants
     public static final String JSON_CLOUD_ID = "cloudId";
+
     public static final String JSON_CLOUD_PROVIDER_NAME = "cloudProviderName";
+
     public static final String JSON_CLOUD_TYPE = "cloudType";
+
     public static final String JSON_SECURITY_GROUP = "securityGroup";
+
     public static final String JSON_SUBNET = "subnet";
+
     public static final String JSON_SSH_CREDENTIALS = "sshCredentials";
+
     public static final String JSON_ENDPOINT = "endpoint";
+
     public static final String JSON_SCOPE = "scope";
+
     public static final String JSON_IDENTITY_VERSION = "identityVersion";
+
     public static final String JSON_DEFAULT_NETWORK = "defaultNetwork";
+
     public static final String JSON_CREDENTIALS = "credentials";
+
     public static final String JSON_BLACKLIST = "blacklist";
 
     @JsonProperty(JSON_CLOUD_ID)

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/CloudDefinition.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/CloudDefinition.java
@@ -27,10 +27,7 @@ public class CloudDefinition implements Serializable {
     @JsonProperty("cloudId")
     private String cloudId = null;
 
-    // @JsonProperty("cloudProviderName")
-    // private String cloudProviderName = null;
-
-    @JsonProperty("cloudProvider")
+    @JsonProperty("cloudProviderName")
     private CloudProviderType cloudProvider = null;
 
     @JsonProperty("cloudType")

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/CloudDefinition.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/CloudDefinition.java
@@ -27,8 +27,11 @@ public class CloudDefinition implements Serializable {
     @JsonProperty("cloudId")
     private String cloudId = null;
 
-    @JsonProperty("cloudProviderName")
-    private String cloudProviderName = null;
+    // @JsonProperty("cloudProviderName")
+    // private String cloudProviderName = null;
+
+    @JsonProperty("cloudProvider")
+    private CloudProviderType cloudProvider = null;
 
     @JsonProperty("cloudType")
     private CloudType cloudType = null;

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/CloudType.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/CloudType.java
@@ -26,7 +26,7 @@ public enum CloudType {
 
     SIMULATION("SIMULATION");
 
-    private String value;
+    private final String value;
 
     CloudType(String value) {
         this.value = value;

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/Cluster.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/Cluster.java
@@ -1,8 +1,3 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/.
- */
 package org.ow2.proactive.sal.model;
 
 import java.util.List;
@@ -18,7 +13,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-
 @Getter
 @Setter
 @AllArgsConstructor
@@ -26,31 +20,41 @@ import lombok.Setter;
 @Entity
 @Table(name = "CLUSTER")
 public class Cluster {
+
+    // JSON field constants
+    public static final String JSON_CLUSTER_ID = "clusterId";
+    public static final String JSON_NAME = "name";
+    public static final String JSON_MASTER_NODE = "master-node";
+    public static final String JSON_NODES = "nodes";
+    public static final String JSON_STATUS = "status";
+    public static final String JSON_ENV_VARS = "env-var-script";
+
     @Id
     @GeneratedValue(generator = "system-uuid")
     @GenericGenerator(name = "system-uuid", strategy = "uuid")
     @Column(name = "CLUSTER_ID")
+    @JsonProperty(JSON_CLUSTER_ID)
     private String clusterId = null;
 
     @Column(name = "NAME")
-    @JsonProperty("name")
+    @JsonProperty(JSON_NAME)
     private String name = null;
 
     @Column(name = "MASTER_NODE")
-    @JsonProperty("master-node")
+    @JsonProperty(JSON_MASTER_NODE)
     private String masterNode;
 
     @Column(name = "NODES")
-    @JsonProperty("nodes")
+    @JsonProperty(JSON_NODES)
     @OneToMany(fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.REFRESH)
     private List<ClusterNodeDefinition> nodes;
 
     // TODO: Change this into Enum
     @Column(name = "STATUS")
-    @JsonProperty("status")
+    @JsonProperty(JSON_STATUS)
     private String status = "defined";
 
     @Column(name = "ENV", columnDefinition = "text", length = 65535)
-    @JsonProperty("env-var-script")
+    @JsonProperty(JSON_ENV_VARS)
     private String envVars;
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/Cluster.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/Cluster.java
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 package org.ow2.proactive.sal.model;
 
 import java.util.List;
@@ -13,6 +18,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+
 @Getter
 @Setter
 @AllArgsConstructor
@@ -23,10 +29,15 @@ public class Cluster {
 
     // JSON field constants
     public static final String JSON_CLUSTER_ID = "clusterId";
+
     public static final String JSON_NAME = "name";
+
     public static final String JSON_MASTER_NODE = "master-node";
+
     public static final String JSON_NODES = "nodes";
+
     public static final String JSON_STATUS = "status";
+
     public static final String JSON_ENV_VARS = "env-var-script";
 
     @Id

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/ClusterApplication.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/ClusterApplication.java
@@ -6,7 +6,6 @@
 package org.ow2.proactive.sal.model;
 
 import java.util.Arrays;
-
 import java.util.Optional;
 
 import javax.persistence.*;
@@ -20,6 +19,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+
 @Getter
 @Setter
 @AllArgsConstructor
@@ -28,10 +28,15 @@ public class ClusterApplication {
 
     // JSON field constants
     public static final String JSON_APP_NAME = "appName";
+
     public static final String JSON_CLUSTER_NAME = "clusterName";
+
     public static final String JSON_APP_FILE = "appFile";
+
     public static final String JSON_PACKAGE_MANAGER = "packageManager";
+
     public static final String JSON_ACTION = "action";
+
     public static final String JSON_FLAGS = "flags";
 
     @Id
@@ -59,7 +64,6 @@ public class ClusterApplication {
     @JsonProperty(JSON_FLAGS)
     private String flags = "";
 
-
     @Getter
     public enum PackageManagerEnum {
         HELM("helm", "helm upgrade --install"),
@@ -67,6 +71,7 @@ public class ClusterApplication {
         KUBEVELA("kubevela", "vela up -f ");
 
         private final String name;
+
         private final String command;
 
         PackageManagerEnum(String name, String command) {
@@ -76,8 +81,8 @@ public class ClusterApplication {
 
         public static PackageManagerEnum getPackageManagerEnumByName(String name) {
             Optional<PackageManagerEnum> packageManager = Arrays.stream(PackageManagerEnum.values())
-                    .filter(pm -> pm.name.equals(name))
-                    .findFirst();
+                                                                .filter(pm -> pm.name.equals(name))
+                                                                .findFirst();
             return packageManager.orElse(null);
         }
     }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/ClusterApplication.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/ClusterApplication.java
@@ -6,7 +6,7 @@
 package org.ow2.proactive.sal.model;
 
 import java.util.Arrays;
-import java.util.List;
+
 import java.util.Optional;
 
 import javax.persistence.*;
@@ -20,46 +20,53 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class ClusterApplication {
+
+    // JSON field constants
+    public static final String JSON_APP_NAME = "appName";
+    public static final String JSON_CLUSTER_NAME = "clusterName";
+    public static final String JSON_APP_FILE = "appFile";
+    public static final String JSON_PACKAGE_MANAGER = "packageManager";
+    public static final String JSON_ACTION = "action";
+    public static final String JSON_FLAGS = "flags";
+
     @Id
     @GeneratedValue(generator = "system-uuid")
     @GenericGenerator(name = "system-uuid", strategy = "uuid")
     private String applicationId = null;
 
-    @JsonProperty("appName")
+    @JsonProperty(JSON_APP_NAME)
     private String appName = null;
 
     private String clusterName = null;
 
-    //TODO    change this
+    // TODO: change this
     private PackageManagerEnum yamlManager = null;
 
-    @JsonProperty("appFile")
+    @JsonProperty(JSON_APP_FILE)
     private String appFile = null;
 
-    @JsonProperty("packageManager")
+    @JsonProperty(JSON_PACKAGE_MANAGER)
     private String packageManager = null;
 
-    @JsonProperty("action")
+    @JsonProperty(JSON_ACTION)
     private String action = null;
 
-    @JsonProperty("flags")
+    @JsonProperty(JSON_FLAGS)
     private String flags = "";
 
+
+    @Getter
     public enum PackageManagerEnum {
         HELM("helm", "helm upgrade --install"),
         KUBECTL("kubectl", "kubectl apply -f "),
         KUBEVELA("kubevela", "vela up -f ");
 
-        @Getter
         private final String name;
-
-        @Getter
         private final String command;
 
         PackageManagerEnum(String name, String command) {
@@ -69,10 +76,9 @@ public class ClusterApplication {
 
         public static PackageManagerEnum getPackageManagerEnumByName(String name) {
             Optional<PackageManagerEnum> packageManager = Arrays.stream(PackageManagerEnum.values())
-                                                                .filter(pm -> pm.name.equals(name))
-                                                                .findFirst();
+                    .filter(pm -> pm.name.equals(name))
+                    .findFirst();
             return packageManager.orElse(null);
         }
-
     }
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/ClusterDefinition.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/ClusterDefinition.java
@@ -19,16 +19,26 @@ import lombok.*;
 @Setter
 @ToString(callSuper = true)
 public class ClusterDefinition {
-    @JsonProperty("name")
+
+    // JSON field constants
+    public static final String JSON_NAME = "name";
+
+    public static final String JSON_NODES = "nodes";
+
+    public static final String JSON_MASTER_NODE = "master-node";
+
+    public static final String JSON_ENV_VAR = "env-var";
+
+    @JsonProperty(JSON_NAME)
     private String name = null;
 
-    @JsonProperty("nodes")
+    @JsonProperty(JSON_NODES)
     private List<ClusterNodeDefinition> nodes;
 
-    @JsonProperty("master-node")
+    @JsonProperty(JSON_MASTER_NODE)
     private String masterNode;
 
-    @JsonProperty("env-var")
+    @JsonProperty(JSON_ENV_VAR)
     private Map<String, String> envVars;
 
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/ClusterNodeDefinition.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/ClusterNodeDefinition.java
@@ -22,17 +22,25 @@ import lombok.*;
 @Setter
 @Table(name = "CLUSTER_NODE_DEF")
 public class ClusterNodeDefinition {
+
+    // JSON field constants
+    public static final String JSON_NODE_NAME = "nodeName";
+
+    public static final String JSON_NODE_CANDIDATE_ID = "nodeCandidateId";
+
+    public static final String JSON_CLOUD_ID = "cloudId";
+
     @Id
     @Column(name = "NAME")
-    @JsonProperty("nodeName")
+    @JsonProperty(JSON_NODE_NAME)
     private String name = null;
 
     @Column(name = "NC")
-    @JsonProperty("nodeCandidateId")
+    @JsonProperty(JSON_NODE_CANDIDATE_ID)
     private String nodeCandidateId = null;
 
     @Column(name = "CLOUD_ID")
-    @JsonProperty("cloudId")
+    @JsonProperty(JSON_CLOUD_ID)
     private String cloudId = null;
 
     private String state = "";
@@ -46,5 +54,4 @@ public class ClusterNodeDefinition {
     public String getNodeTaskName(String clusterName) {
         return this.name + "-" + clusterName + "_Task";
     }
-
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/CommandsInstallation.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/CommandsInstallation.java
@@ -15,6 +15,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.*;
 
 
+/**
+ * Represents installation details for commands, extending the AbstractInstallation class.
+ */
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString(callSuper = true)
@@ -24,52 +27,77 @@ import lombok.*;
 @JsonTypeName(value = "commands")
 public class CommandsInstallation extends AbstractInstallation {
 
+    // JSON field constants
+    public static final String JSON_PRE_INSTALL = "preInstall";
+
+    public static final String JSON_INSTALL = "install";
+
+    public static final String JSON_POST_INSTALL = "postInstall";
+
+    public static final String JSON_PRE_START = "preStart";
+
+    public static final String JSON_START = "start";
+
+    public static final String JSON_POST_START = "postStart";
+
+    public static final String JSON_PRE_STOP = "preStop";
+
+    public static final String JSON_STOP = "stop";
+
+    public static final String JSON_POST_STOP = "postStop";
+
+    public static final String JSON_UPDATE_CMD = "update";
+
+    public static final String JSON_START_DETECTION = "startDetection";
+
+    public static final String JSON_OPERATING_SYSTEM = "operatingSystem";
+
     @Column(name = "PREINSTALL", columnDefinition = "TEXT")
-    @JsonProperty("preInstall")
+    @JsonProperty(JSON_PRE_INSTALL)
     private String preInstall;
 
     @Column(name = "INSTALL", columnDefinition = "TEXT")
-    @JsonProperty("install")
+    @JsonProperty(JSON_INSTALL)
     private String install;
 
     @Column(name = "POSTINSTALL", columnDefinition = "TEXT")
-    @JsonProperty("postInstall")
+    @JsonProperty(JSON_POST_INSTALL)
     private String postInstall;
 
     @Column(name = "PRESTART", columnDefinition = "TEXT")
-    @JsonProperty("preStart")
+    @JsonProperty(JSON_PRE_START)
     private String preStart;
 
     @Column(name = "START", columnDefinition = "TEXT")
-    @JsonProperty("start")
+    @JsonProperty(JSON_START)
     private String start;
 
     @Column(name = "POSTSTART", columnDefinition = "TEXT")
-    @JsonProperty("postStart")
+    @JsonProperty(JSON_POST_START)
     private String postStart;
 
     @Column(name = "PRESTOP", columnDefinition = "TEXT")
-    @JsonProperty("preStop")
+    @JsonProperty(JSON_PRE_STOP)
     private String preStop;
 
     @Column(name = "STOP", columnDefinition = "TEXT")
-    @JsonProperty("stop")
+    @JsonProperty(JSON_STOP)
     private String stop;
 
     @Column(name = "POSTSTOP", columnDefinition = "TEXT")
-    @JsonProperty("postStop")
+    @JsonProperty(JSON_POST_STOP)
     private String postStop;
 
     @Column(name = "UPDATE_CMD", columnDefinition = "TEXT")
-    @JsonProperty("update")
+    @JsonProperty(JSON_UPDATE_CMD)
     private String updateCmd;
 
     @Column(name = "START_DETECTION", columnDefinition = "TEXT")
-    @JsonProperty("startDetection")
+    @JsonProperty(JSON_START_DETECTION)
     private String startDetection;
 
     @Embedded
-    @JsonProperty("operatingSystem")
+    @JsonProperty(JSON_OPERATING_SYSTEM)
     private OperatingSystemType operatingSystemType;
 
     @Override

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/Communication.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/Communication.java
@@ -22,9 +22,14 @@ import lombok.*;
 @ToString(callSuper = true)
 public class Communication implements Serializable {
 
-    @JsonProperty("portProvided")
+    // JSON field constants
+    public static final String JSON_PORT_PROVIDED = "portProvided";
+
+    public static final String JSON_PORT_REQUIRED = "portRequired";
+
+    @JsonProperty(JSON_PORT_PROVIDED)
     private String portProvided;
 
-    @JsonProperty("portRequired")
+    @JsonProperty(JSON_PORT_REQUIRED)
     private String portRequired;
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/Credential.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/Credential.java
@@ -14,6 +14,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 
+/**
+ * Represents credentials for authentication and access.
+ */
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
@@ -22,15 +25,24 @@ import lombok.*;
 @Embeddable
 public class Credential implements Serializable {
 
-    @JsonProperty("user")
+    // JSON field constants
+    public static final String JSON_USER = "user";
+
+    public static final String JSON_SECRET = "secret";
+
+    public static final String JSON_DOMAIN = "domain";
+
+    public static final String JSON_SUBSCRIPTION_ID = "subscriptionId";
+
+    @JsonProperty(JSON_USER)
     private String user = null;
 
-    @JsonProperty("secret")
+    @JsonProperty(JSON_SECRET)
     private String secret = null;
 
-    @JsonProperty("domain")
+    @JsonProperty(JSON_DOMAIN)
     private String domain = null;
 
-    @JsonProperty("subscriptionId")
+    @JsonProperty(JSON_SUBSCRIPTION_ID)
     private String subscriptionId = null;
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/Credentials.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/Credentials.java
@@ -9,9 +9,14 @@ import java.io.Serializable;
 
 import javax.persistence.*;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.*;
 
 
+/**
+ * Represents a set of credentials for authentication and access.
+ */
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString(callSuper = true)
@@ -20,26 +25,49 @@ import lombok.*;
 @Entity
 @Table(name = "CREDENTIALS")
 public class Credentials implements Serializable {
+
+    // JSON field constants
+    public static final String JSON_CREDENTIALS_ID = "credentialsId";
+
+    public static final String JSON_USER_NAME = "userName";
+
+    public static final String JSON_PASSWORD = "password";
+
+    public static final String JSON_PRIVATE_KEY = "privateKey";
+
+    public static final String JSON_PUBLIC_KEY = "publicKey";
+
+    public static final String JSON_DOMAIN = "domain";
+
+    public static final String JSON_SUBSCRIPTION_ID = "subscriptionId";
+
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "CREDENTIALS_ID")
+    @JsonProperty(JSON_CREDENTIALS_ID)
     private Integer credentialsId;
 
     @Column(name = "USER_NAME")
+    @JsonProperty(JSON_USER_NAME)
     private String userName;
 
     @Column(name = "PASSWORD")
+    @JsonProperty(JSON_PASSWORD)
     private String password;
 
     @Column(name = "PRIVATE_KEY", columnDefinition = "TEXT")
+    @JsonProperty(JSON_PRIVATE_KEY)
     private String privateKey;
 
     @Column(name = "PUBLIC_KEY", columnDefinition = "TEXT")
+    @JsonProperty(JSON_PUBLIC_KEY)
     private String publicKey;
 
     @Column(name = "DOMAIN")
+    @JsonProperty(JSON_DOMAIN)
     private String domain;
 
     @Column(name = "SUBSCRIPTION_ID")
+    @JsonProperty(JSON_SUBSCRIPTION_ID)
     private String subscriptionId;
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/Deployment.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/Deployment.java
@@ -16,16 +16,33 @@ import com.fasterxml.jackson.annotation.*;
 import lombok.*;
 
 
+/**
+ * Represents a Deployment with its associated details.
+ */
 @NoArgsConstructor
 @Getter
 @Setter
 @Entity
 @Table(name = "DEPLOYMENT")
-@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "nodeName", scope = Deployment.class)
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = Deployment.JSON_NODE_NAME, scope = Deployment.class)
 public class Deployment implements Serializable {
+
+    // JSON field constants
+    public static final String JSON_NODE_NAME = "nodeName";
+
+    public static final String JSON_CLOUD_ID = "cloudId";
+
+    public static final String JSON_TASK_ID = "taskId";
+
+    public static final String JSON_IS_DEPLOYED = "isDeployed";
+
+    public static final String JSON_INSTANCE_ID = "instanceId";
+
+    public static final String JSON_IP_ADDRESS = "ipAddress";
 
     @Id
     @Column(name = "NODE_NAME")
+    @JsonProperty(JSON_NODE_NAME)
     private String nodeName;
 
     @OneToOne(fetch = FetchType.EAGER, orphanRemoval = true, cascade = CascadeType.REFRESH)
@@ -39,15 +56,16 @@ public class Deployment implements Serializable {
 
     @ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.REFRESH)
     @JsonIdentityReference(alwaysAsId = true)
-    @JsonProperty("cloudId")
+    @JsonProperty(JSON_CLOUD_ID)
     private PACloud paCloud;
 
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REFRESH)
     @JsonIdentityReference(alwaysAsId = true)
-    @JsonProperty("taskId")
+    @JsonProperty(JSON_TASK_ID)
     private Task task;
 
     @Column(name = "IS_DEPLOYED")
+    @JsonProperty(JSON_IS_DEPLOYED)
     private Boolean isDeployed = false;
 
     @Column(name = "NODE_ACCESS_TOKEN")
@@ -57,9 +75,11 @@ public class Deployment implements Serializable {
     private Long number;
 
     @Column(name = "INSTANCE_ID")
+    @JsonProperty(JSON_INSTANCE_ID)
     private String instanceId;
 
     @Embedded
+    @JsonProperty(JSON_IP_ADDRESS)
     private IpAddress ipAddress = null;
 
     @Column(name = "NODE_TYPE")
@@ -90,20 +110,20 @@ public class Deployment implements Serializable {
         }
     }
 
-    //    This is added for deserialization testing purpose
+    // Added for deserialization testing purpose
     public Deployment(String nodeName) {
         this.nodeName = nodeName;
     }
 
-    //    This is added for deserialization testing purpose
-    @JsonSetter("cloudId")
+    // Added for deserialization testing purpose
+    @JsonSetter(JSON_CLOUD_ID)
     private void setPaCloudById(String cloudId) {
         this.paCloud = new PACloud(cloudId);
         this.paCloud.addDeployment(this);
     }
 
-    //    This is added for deserialization testing purpose
-    @JsonSetter("taskId")
+    // Added for deserialization testing purpose
+    @JsonSetter(JSON_TASK_ID)
     private void setTaskById(String taskId) {
         this.task = new Task(taskId);
         this.task.addDeployment(this);
@@ -111,29 +131,24 @@ public class Deployment implements Serializable {
 
     @Override
     public String toString() {
+        String commonFields = JSON_NODE_NAME + "='" + nodeName + "', " + JSON_IS_DEPLOYED + "='" + isDeployed + "', " +
+                              JSON_INSTANCE_ID + "='" + instanceId + "', " + JSON_IP_ADDRESS + "='" + ipAddress +
+                              "', " + "nodeAccessToken='" + nodeAccessToken + "', " + "number='" + number + "', " +
+                              JSON_CLOUD_ID + "='" +
+                              Optional.ofNullable(paCloud).map(PACloud::getNodeSourceNamePrefix).orElse(null) + "', " +
+                              JSON_TASK_ID + "='" + Optional.ofNullable(task).map(Task::getName).orElse(null) + "'";
+
         switch (deploymentType) {
             case IAAS:
-                return "Deployment{" + "nodeName='" + nodeName + '\'' + ", isDeployed='" + isDeployed.toString() +
-                       '\'' + ", instanceId='" + instanceId + '\'' + ", ipAddress='" + ipAddress + '\'' +
-                       ", nodeAccessToken='" + nodeAccessToken + '\'' + ", number='" + number + '\'' + ", paCloud='" +
-                       Optional.ofNullable(paCloud).map(PACloud::getNodeSourceNamePrefix).orElse(null) + '\'' +
-                       ", task='" + Optional.ofNullable(task).map(Task::getName).orElse(null) + '\'' + ", iaasNode='" +
-                       iaasNode + '\'' + '}';
+                return "Deployment{" + commonFields + ", iaasNode='" + iaasNode + "'}";
             case BYON:
-                return "Deployment{" + "nodeName='" + nodeName + '\'' + ", isDeployed='" + isDeployed.toString() +
-                       '\'' + ", instanceId='" + instanceId + '\'' + ", ipAddress='" + ipAddress + '\'' +
-                       ", nodeAccessToken='" + nodeAccessToken + '\'' + ", number='" + number + '\'' + ", paCloud='" +
-                       paCloud + '\'' + ", task='" + Optional.ofNullable(task).map(Task::getName).orElse(null) + '\'' +
-                       ", byonNode='" + Optional.ofNullable(byonNode).map(ByonNode::getName).orElse(null) + '\'' + '}';
-
+                return "Deployment{" + commonFields + ", byonNode='" +
+                       Optional.ofNullable(byonNode).map(ByonNode::getName).orElse(null) + "'}";
             case EDGE:
-                return "Deployment{" + "nodeName='" + nodeName + '\'' + ", isDeployed='" + isDeployed.toString() +
-                       '\'' + ", instanceId='" + instanceId + '\'' + ", ipAddress='" + ipAddress + '\'' +
-                       ", nodeAccessToken='" + nodeAccessToken + '\'' + ", number='" + number + '\'' + ", paCloud='" +
-                       paCloud + '\'' + ", task='" + Optional.ofNullable(task).map(Task::getName).orElse(null) + '\'' +
-                       ", edgeNode='" + Optional.ofNullable(edgeNode).map(EdgeNode::getName).orElse(null) + '\'' + '}';
+                return "Deployment{" + commonFields + ", edgeNode='" +
+                       Optional.ofNullable(edgeNode).map(EdgeNode::getName).orElse(null) + "'}";
             default:
-                return "Deployment{nodeName='" + nodeName + '}';
+                return "Deployment{" + JSON_NODE_NAME + "='" + nodeName + "'}";
         }
     }
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/Deployment.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/Deployment.java
@@ -11,6 +11,8 @@ import java.util.Optional;
 import javax.persistence.*;
 import javax.ws.rs.NotSupportedException;
 
+import org.ow2.proactive.sal.util.ModelUtils;
+
 import com.fasterxml.jackson.annotation.*;
 
 import lombok.*;
@@ -129,6 +131,15 @@ public class Deployment implements Serializable {
         this.task.addDeployment(this);
     }
 
+    /**
+     * Custom toString() method for the class to format the output.
+     * This method creates a formatted string representation of the class object.
+     * It uses a map of field names (represented as JSON constants) and their corresponding values
+     * to build a human-readable string. The method leverages the {@link ModelUtils#buildToString}
+     * utility method to generate the string, ensuring that all fields are included with proper formatting.
+     *
+     * @return A formatted string representation of the Hardware object, with each field on a new line.
+     */
     @Override
     public String toString() {
         String commonFields = JSON_NODE_NAME + "='" + nodeName + "', " + JSON_IS_DEPLOYED + "='" + isDeployed + "', " +

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/DockerEnvironment.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/DockerEnvironment.java
@@ -25,12 +25,14 @@ import lombok.*;
 @JsonTypeName(value = "docker")
 public class DockerEnvironment extends AbstractInstallation {
 
-    @Column(name = "DOCKER_IMAGE")
-    @JsonProperty("dockerImage")
+    public static final String JSON_DOCKER_IMAGE = "dockerImage";
+
+    public static final String JSON_PORT = "port";
+
+    @JsonProperty(JSON_DOCKER_IMAGE)
     private String dockerImage;
 
-    @Column(name = "PORT")
-    @JsonProperty("port")
+    @JsonProperty(JSON_PORT)
     private String port;
 
     @ElementCollection

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/EdgeNode.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/EdgeNode.java
@@ -32,7 +32,7 @@ import lombok.Setter;
 @Table(name = "EDGE_NODE")
 @Getter
 @Setter
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 public class EdgeNode extends AbstractNode {
 
     @Column(name = "NAME")

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/EdgeNode.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/EdgeNode.java
@@ -5,10 +5,13 @@
  */
 package org.ow2.proactive.sal.model;
 
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Objects;
+import java.util.Map;
 
 import javax.persistence.*;
+
+import org.ow2.proactive.sal.util.ModelUtils;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -87,36 +90,21 @@ public class EdgeNode extends AbstractNode {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("class EdgeNode {\n");
+        Map<String, Object> fields = new LinkedHashMap<>();
+        fields.put(EdgeDefinition.JSON_NAME, name);
+        fields.put(EdgeDefinition.JSON_LOGIN_CREDENTIAL, loginCredential);
+        fields.put(EdgeDefinition.JSON_NODE_PROPERTIES, nodeProperties);
+        fields.put(EdgeDefinition.JSON_PORT, port);
+        fields.put(EdgeDefinition.JSON_REASON, reason);
+        fields.put(EdgeDefinition.JSON_DIAGNOSTIC, diagnostic);
+        fields.put(EdgeDefinition.JSON_USER_ID, userId);
+        fields.put(EdgeDefinition.JSON_ALLOCATED, allocated);
+        fields.put(EdgeDefinition.JSON_JOB_ID, jobId);
+        fields.put(EdgeDefinition.JSON_SYSTEM_ARCH, systemArch);
+        fields.put(EdgeDefinition.JSON_SCRIPT_URL, scriptURL);
+        fields.put(EdgeDefinition.JSON_JAR_URL, jarURL);
 
-        sb.append("    name: ").append(toIndentedString(this.name)).append("\n");
-        sb.append("    id: ").append(toIndentedString(this.id)).append("\n");
-        sb.append("    loginCredential: ").append(toIndentedString(this.loginCredential)).append("\n");
-        sb.append("    ipAddresses: ").append(toIndentedString(this.ipAddresses)).append("\n");
-        sb.append("    nodeProperties: ").append(toIndentedString(this.nodeProperties)).append("\n");
-        sb.append("    reason: ").append(toIndentedString(this.reason)).append("\n");
-        sb.append("    diagnostic: ").append(toIndentedString(this.diagnostic)).append("\n");
-        sb.append("    nodeCandidate: ").append(toIndentedString(this.nodeCandidate)).append("\n");
-        sb.append("    userId: ").append(toIndentedString(this.userId)).append("\n");
-        sb.append("    allocated: ").append(toIndentedString(this.allocated)).append("\n");
-        sb.append("    jobId: ").append(toIndentedString(this.jobId)).append("\n");
-        sb.append("    systemArch: ").append(toIndentedString(this.systemArch)).append("\n");
-        sb.append("    scriptURL: ").append(toIndentedString(this.scriptURL)).append("\n");
-        sb.append("    jarURL: ").append(toIndentedString(this.jarURL)).append("\n");
-        sb.append("}");
-        return sb.toString();
-    }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
+        return ModelUtils.buildToString(EdgeNode.class.getSimpleName(), fields);
     }
 
     @PreRemove

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/EdgeNode.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/EdgeNode.java
@@ -88,6 +88,15 @@ public class EdgeNode extends AbstractNode {
         return "EDGE_NS_" + this.systemArch + "_" + this.id;
     }
 
+    /**
+     * Custom toString() method for the class to format the output.
+     * This method creates a formatted string representation of the class object.
+     * It uses a map of field names (represented as JSON constants) and their corresponding values
+     * to build a human-readable string. The method leverages the {@link ModelUtils#buildToString}
+     * utility method to generate the string, ensuring that all fields are included with proper formatting.
+     *
+     * @return A formatted string representation of the Hardware object, with each field on a new line.
+     */
     @Override
     public String toString() {
         Map<String, Object> fields = new LinkedHashMap<>();

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/EmsDeploymentDefinition.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/EmsDeploymentDefinition.java
@@ -23,13 +23,20 @@ import lombok.*;
 @ToString(callSuper = true)
 public class EmsDeploymentDefinition implements Serializable {
 
-    @JsonProperty("nodeNames")
+    // Expose JSON field names as constants
+    public static final String JSON_NODE_NAMES = "nodeNames";
+
+    public static final String JSON_AUTHORIZATION_BEARER = "authorizationBearer";
+
+    public static final String JSON_IS_PRIVATE_IP = "isPrivateIp";
+
+    @JsonProperty(JSON_NODE_NAMES)
     private List<String> nodeNames;
 
     //TODO: This should be refactored to extend EmsDeploymentDefinitionForNode class (After Morphemic)
-    @JsonProperty("authorizationBearer")
+    @JsonProperty(JSON_AUTHORIZATION_BEARER)
     private String authorizationBearer;
 
-    @JsonProperty("isPrivateIp")
+    @JsonProperty(JSON_IS_PRIVATE_IP)
     private boolean isPrivateIP;
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/EmsDeploymentDefinitionForNode.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/EmsDeploymentDefinitionForNode.java
@@ -22,10 +22,14 @@ import lombok.*;
 @ToString(callSuper = true)
 public class EmsDeploymentDefinitionForNode implements Serializable {
 
-    @JsonProperty("authorizationBearer")
+    public static final String JSON_AUTHORIZATION_BEARER = "authorizationBearer";
+
+    public static final String JSON_IS_PRIVATE_IP = "isPrivateIp";
+
+    @JsonProperty(JSON_AUTHORIZATION_BEARER)
     private String authorizationBearer;
 
-    @JsonProperty("isPrivateIp")
+    @JsonProperty(JSON_IS_PRIVATE_IP)
     private boolean isPrivateIP;
 
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/Environment.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/Environment.java
@@ -1,12 +1,20 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 package org.ow2.proactive.sal.model;
 
 import java.io.Serializable;
-import java.util.Map;
 import java.util.LinkedHashMap;
+import java.util.Map;
+
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+
+import org.ow2.proactive.sal.util.ModelUtils;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -15,7 +23,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.ow2.proactive.sal.util.ModelUtils;
+
 
 /**
  * Node candidate environment
@@ -36,6 +44,15 @@ public class Environment implements Serializable {
     @JsonProperty(JSON_RUNTIME)
     private Runtime runtime = null;
 
+    /**
+     * Custom toString() method for the class to format the output.
+     * This method creates a formatted string representation of the class object.
+     * It uses a map of field names (represented as JSON constants) and their corresponding values
+     * to build a human-readable string. The method leverages the {@link ModelUtils#buildToString}
+     * utility method to generate the string, ensuring that all fields are included with proper formatting.
+     *
+     * @return A formatted string representation of the Hardware object, with each field on a new line.
+     */
     @Override
     public String toString() {
         // Using LinkedHashMap to preserve field order

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/Environment.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/Environment.java
@@ -1,13 +1,8 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/.
- */
 package org.ow2.proactive.sal.model;
 
 import java.io.Serializable;
-import java.util.Objects;
-
+import java.util.Map;
+import java.util.LinkedHashMap;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
@@ -16,19 +11,29 @@ import javax.persistence.Enumerated;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
-
+import lombok.Setter;
+import org.ow2.proactive.sal.util.ModelUtils;
 
 /**
  * Node candidate environment
  */
 @AllArgsConstructor
 @NoArgsConstructor
+@Getter
+@Setter
 @Embeddable
+@EqualsAndHashCode
 public class Environment implements Serializable {
+
+    // JSON Constants
+    public static final String JSON_RUNTIME = "runtime";
+
     @Column(name = "RUNTIME")
     @Enumerated(EnumType.STRING)
-    @JsonProperty("runtime")
+    @JsonProperty(JSON_RUNTIME)
     private Runtime runtime = null;
 
     public Environment runtime(Runtime runtime) {
@@ -36,53 +41,12 @@ public class Environment implements Serializable {
         return this;
     }
 
-    /**
-     * Get runtime
-     * @return runtime
-     **/
-    public Runtime getRuntime() {
-        return runtime;
-    }
-
-    public void setRuntime(Runtime runtime) {
-        this.runtime = runtime;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Environment environment = (Environment) o;
-        return Objects.equals(this.runtime, environment.runtime);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(runtime);
-    }
-
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("class Environment {\n");
+        // Using LinkedHashMap to preserve field order
+        Map<String, Object> fields = new LinkedHashMap<>();
+        fields.put(JSON_RUNTIME, runtime);
 
-        sb.append("    runtime: ").append(toIndentedString(runtime)).append("\n");
-        sb.append("}");
-        return sb.toString();
-    }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
+        return ModelUtils.buildToString(Environment.class.getSimpleName(), fields);
     }
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/Environment.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/Environment.java
@@ -36,11 +36,6 @@ public class Environment implements Serializable {
     @JsonProperty(JSON_RUNTIME)
     private Runtime runtime = null;
 
-    public Environment runtime(Runtime runtime) {
-        this.runtime = runtime;
-        return this;
-    }
-
     @Override
     public String toString() {
         // Using LinkedHashMap to preserve field order

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/GeoLocation.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/GeoLocation.java
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 package org.ow2.proactive.sal.model;
 
 import java.io.Serializable;
@@ -7,14 +12,15 @@ import java.util.Map;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 
+import org.ow2.proactive.sal.util.ModelUtils;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.ow2.proactive.sal.util.ModelUtils;
 
 
 /**
@@ -30,8 +36,11 @@ public class GeoLocation implements Serializable {
 
     // JSON field names as constants
     public static final String JSON_CITY = "city";
+
     public static final String JSON_COUNTRY = "country";
+
     public static final String JSON_LATITUDE = "latitude";
+
     public static final String JSON_LONGITUDE = "longitude";
 
     @Column(name = "CITY")

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/GeoLocation.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/GeoLocation.java
@@ -1,12 +1,8 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/.
- */
 package org.ow2.proactive.sal.model;
 
 import java.io.Serializable;
-import java.util.Objects;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
@@ -15,6 +11,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import org.ow2.proactive.sal.util.ModelUtils;
 
 
 /**
@@ -23,21 +23,31 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Embeddable
+@Getter
+@Setter
+@EqualsAndHashCode
 public class GeoLocation implements Serializable {
+
+    // JSON field names as constants
+    public static final String JSON_CITY = "city";
+    public static final String JSON_COUNTRY = "country";
+    public static final String JSON_LATITUDE = "latitude";
+    public static final String JSON_LONGITUDE = "longitude";
+
     @Column(name = "CITY")
-    @JsonProperty("city")
+    @JsonProperty(JSON_CITY)
     private String city = null;
 
     @Column(name = "COUNTRY")
-    @JsonProperty("country")
+    @JsonProperty(JSON_COUNTRY)
     private String country = null;
 
     @Column(name = "LATITUDE")
-    @JsonProperty("latitude")
+    @JsonProperty(JSON_LATITUDE)
     private Double latitude = null;
 
     @Column(name = "LONGITUDE")
-    @JsonProperty("longitude")
+    @JsonProperty(JSON_LONGITUDE)
     private Double longitude = null;
 
     public GeoLocation(GeoLocationData geoLocationData) {
@@ -47,114 +57,14 @@ public class GeoLocation implements Serializable {
         this.longitude = geoLocationData.getLongitude();
     }
 
-    public GeoLocation city(String city) {
-        this.city = city;
-        return this;
-    }
-
-    /**
-     * City of the location
-     * @return city
-     **/
-    public String getCity() {
-        return city;
-    }
-
-    public void setCity(String city) {
-        this.city = city;
-    }
-
-    public GeoLocation country(String country) {
-        this.country = country;
-        return this;
-    }
-
-    /**
-     * An ISO 3166-1 alpha-2 country code
-     * @return country
-     **/
-    public String getCountry() {
-        return country;
-    }
-
-    public void setCountry(String country) {
-        this.country = country;
-    }
-
-    public GeoLocation latitude(Double latitude) {
-        this.latitude = latitude;
-        return this;
-    }
-
-    /**
-     * Latitude of the location in decimal degrees
-     * @return latitude
-     **/
-    public Double getLatitude() {
-        return latitude;
-    }
-
-    public void setLatitude(Double latitude) {
-        this.latitude = latitude;
-    }
-
-    public GeoLocation longitude(Double longitude) {
-        this.longitude = longitude;
-        return this;
-    }
-
-    /**
-     * Longitude of the location in decimal degrees
-     * @return longitude
-     **/
-    public Double getLongitude() {
-        return longitude;
-    }
-
-    public void setLongitude(Double longitude) {
-        this.longitude = longitude;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        GeoLocation geoLocation = (GeoLocation) o;
-        return Objects.equals(this.city, geoLocation.city) && Objects.equals(this.country, geoLocation.country) &&
-               Objects.equals(this.latitude, geoLocation.latitude) &&
-               Objects.equals(this.longitude, geoLocation.longitude);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(city, country, latitude, longitude);
-    }
-
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("class GeoLocation {\n");
+        Map<String, Object> fields = new LinkedHashMap<>();
+        fields.put(JSON_CITY, city);
+        fields.put(JSON_COUNTRY, country);
+        fields.put(JSON_LATITUDE, latitude);
+        fields.put(JSON_LONGITUDE, longitude);
 
-        sb.append("    city: ").append(toIndentedString(city)).append("\n");
-        sb.append("    country: ").append(toIndentedString(country)).append("\n");
-        sb.append("    latitude: ").append(toIndentedString(latitude)).append("\n");
-        sb.append("    longitude: ").append(toIndentedString(longitude)).append("\n");
-        sb.append("}");
-        return sb.toString();
-    }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
+        return ModelUtils.buildToString(GeoLocation.class.getSimpleName(), fields);
     }
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/GeoLocationData.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/GeoLocationData.java
@@ -42,9 +42,15 @@ public class GeoLocationData {
         return Objects.equals(this.cloud, geoLocation.cloud) && Objects.equals(this.region, geoLocation.region);
     }
 
-    @Override
     public String toString() {
-        return "GeoLocationData{" + "city='" + city + '\'' + ", country='" + country + '\'' + ", latitude=" + latitude +
-               ", longitude=" + longitude + ", region='" + region + '\'' + ", cloud='" + cloud + '\'' + '}';
+        return "GeoLocationData{" +
+                GeoLocation.JSON_CITY + "='" + city + '\'' +
+                ", " + GeoLocation.JSON_COUNTRY + "='" + country + '\'' +
+                ", " + GeoLocation.JSON_LATITUDE + "=" + latitude +
+                ", " + GeoLocation.JSON_LONGITUDE + "=" + longitude +
+                ", region='" + region + '\'' +
+                ", cloud='" + cloud + '\'' +
+                '}';
     }
+
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/GeoLocationData.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/GeoLocationData.java
@@ -43,14 +43,10 @@ public class GeoLocationData {
     }
 
     public String toString() {
-        return "GeoLocationData{" +
-                GeoLocation.JSON_CITY + "='" + city + '\'' +
-                ", " + GeoLocation.JSON_COUNTRY + "='" + country + '\'' +
-                ", " + GeoLocation.JSON_LATITUDE + "=" + latitude +
-                ", " + GeoLocation.JSON_LONGITUDE + "=" + longitude +
-                ", region='" + region + '\'' +
-                ", cloud='" + cloud + '\'' +
-                '}';
+        return "GeoLocationData{" + GeoLocation.JSON_CITY + "='" + city + '\'' + ", " + GeoLocation.JSON_COUNTRY +
+               "='" + country + '\'' + ", " + GeoLocation.JSON_LATITUDE + "=" + latitude + ", " +
+               GeoLocation.JSON_LONGITUDE + "=" + longitude + ", region='" + region + '\'' + ", cloud='" + cloud +
+               '\'' + '}';
     }
 
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/Hardware.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/Hardware.java
@@ -256,18 +256,18 @@ public class Hardware implements Serializable {
         StringBuilder sb = new StringBuilder();
         sb.append("class Hardware {\n");
 
-        sb.append("    id: ").append(toIndentedString(id)).append("\n");
-        sb.append("    name: ").append(toIndentedString(name)).append("\n");
-        sb.append("    providerId: ").append(toIndentedString(providerId)).append("\n");
-        sb.append("    cores: ").append(toIndentedString(cores)).append("\n");
-        sb.append("    cpuFrequency: ").append(toIndentedString(cpuFrequency)).append("\n");
-        sb.append("    ram: ").append(toIndentedString(ram)).append("\n");
-        sb.append("    disk: ").append(toIndentedString(disk)).append("\n");
-        sb.append("    fpga: ").append(toIndentedString(fpga)).append("\n");
-        sb.append("    gpu: ").append(toIndentedString(gpu)).append("\n");
-        sb.append("    location: ").append(toIndentedString(location)).append("\n");
-        sb.append("    state: ").append(toIndentedString(state)).append("\n");
-        sb.append("    owner: ").append(toIndentedString(owner)).append("\n");
+        sb.append("    ").append(JSON_ID).append(": ").append(toIndentedString(id)).append("\n");
+        sb.append("    ").append(JSON_NAME).append(": ").append(toIndentedString(name)).append("\n");
+        sb.append("    ").append(JSON_PROVIDER_ID).append(": ").append(toIndentedString(providerId)).append("\n");
+        sb.append("    ").append(JSON_CORES).append(": ").append(toIndentedString(cores)).append("\n");
+        sb.append("    ").append(JSON_CPU_FREQUENCY).append(": ").append(toIndentedString(cpuFrequency)).append("\n");
+        sb.append("    ").append(JSON_RAM).append(": ").append(toIndentedString(ram)).append("\n");
+        sb.append("    ").append(JSON_DISK).append(": ").append(toIndentedString(disk)).append("\n");
+        sb.append("    ").append(JSON_FPGA).append(": ").append(toIndentedString(fpga)).append("\n");
+        sb.append("    ").append(JSON_GPU).append(": ").append(toIndentedString(gpu)).append("\n");
+        sb.append("    ").append(JSON_LOCATION).append(": ").append(toIndentedString(location)).append("\n");
+        sb.append("    ").append(JSON_STATE).append(": ").append(toIndentedString(state)).append("\n");
+        sb.append("    ").append(JSON_OWNER).append(": ").append(toIndentedString(owner)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/Hardware.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/Hardware.java
@@ -8,9 +8,12 @@ package org.ow2.proactive.sal.model;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import javax.persistence.*;
+
+import org.ow2.proactive.sal.util.ModelUtils;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -23,7 +26,7 @@ import lombok.experimental.Accessors;
 
 
 /**
- * Represents a hardware offer by a cloud
+ * Represents a hardware offer by a cloud or edge device
  */
 @AllArgsConstructor
 @NoArgsConstructor
@@ -34,6 +37,83 @@ import lombok.experimental.Accessors;
 @Entity
 @Table(name = "HARDWARE")
 public class Hardware implements Serializable {
+    // Class name constant
+    public static final String CLASS_NAME = "Hardware";
+
+    // JSON property constants
+    public static final String JSON_ID = "id";
+
+    public static final String JSON_NAME = "name";
+
+    public static final String JSON_PROVIDER_ID = "providerId";
+
+    public static final String JSON_CORES = "cores";
+
+    public static final String JSON_CPU_FREQUENCY = "cpuFrequency";
+
+    public static final String JSON_RAM = "ram";
+
+    public static final String JSON_DISK = "disk";
+
+    public static final String JSON_FPGA = "fpga";
+
+    public static final String JSON_GPU = "gpu";
+
+    public static final String JSON_LOCATION = "location";
+
+    public static final String JSON_STATE = "state";
+
+    public static final String JSON_OWNER = "owner";
+
+    @Id
+    @Column(name = "ID")
+    @JsonProperty(JSON_ID)
+    private String id = null;
+
+    @Column(name = "NAME")
+    @JsonProperty(JSON_NAME)
+    private String name = null;
+
+    @Column(name = "PROVIDER_ID")
+    @JsonProperty(JSON_PROVIDER_ID)
+    private String providerId = null;
+
+    @Column(name = "CORES")
+    @JsonProperty(JSON_CORES)
+    private Integer cores = null;
+
+    @Column(name = "CPU_FREQUENCY")
+    @JsonProperty(JSON_CPU_FREQUENCY)
+    private Double cpuFrequency = null;
+
+    @Column(name = "RAM")
+    @JsonProperty(JSON_RAM)
+    private Long ram = null;
+
+    @Column(name = "DISK")
+    @JsonProperty(JSON_DISK)
+    private Double disk = null;
+
+    @Column(name = "FPGA")
+    @JsonProperty(JSON_FPGA)
+    private Integer fpga = null;
+
+    @Column(name = "GPU")
+    @JsonProperty(JSON_GPU)
+    private Integer gpu = null;
+
+    @ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    @JsonProperty(JSON_LOCATION)
+    private Location location = null;
+
+    @Column(name = "STATE")
+    @Enumerated(EnumType.STRING)
+    @JsonProperty(JSON_STATE)
+    private DiscoveryItemState state = null;
+
+    @Column(name = "OWNER")
+    @JsonProperty(JSON_OWNER)
+    private String owner = null;
 
     // FPGA mappings for cloud providers
     private static final Map<CloudProviderType, Map<String, Integer>> CLOUD_FPGA_MAPPINGS;
@@ -146,80 +226,6 @@ public class Hardware implements Serializable {
         CLOUD_GPU_MAPPINGS = Collections.unmodifiableMap(tempGpuMappings);
     }
 
-    public static final String JSON_ID = "id";
-
-    public static final String JSON_NAME = "name";
-
-    public static final String JSON_PROVIDER_ID = "providerId";
-
-    public static final String JSON_CORES = "cores";
-
-    public static final String JSON_CPU_FREQUENCY = "cpuFrequency";
-
-    public static final String JSON_RAM = "ram";
-
-    public static final String JSON_DISK = "disk";
-
-    public static final String JSON_FPGA = "fpga";
-
-    public static final String JSON_GPU = "gpu";
-
-    public static final String JSON_LOCATION = "location";
-
-    public static final String JSON_STATE = "state";
-
-    public static final String JSON_OWNER = "owner";
-
-    @Id
-    @Column(name = "ID")
-    @JsonProperty(JSON_ID)
-    private String id = null;
-
-    @Column(name = "NAME")
-    @JsonProperty(JSON_NAME)
-    private String name = null;
-
-    @Column(name = "PROVIDER_ID")
-    @JsonProperty(JSON_PROVIDER_ID)
-    private String providerId = null;
-
-    @Column(name = "CORES")
-    @JsonProperty(JSON_CORES)
-    private Integer cores = null;
-
-    @Column(name = "CPU_FREQUENCY")
-    @JsonProperty(JSON_CPU_FREQUENCY)
-    private Double cpuFrequency = null;
-
-    @Column(name = "RAM")
-    @JsonProperty(JSON_RAM)
-    private Long ram = null;
-
-    @Column(name = "DISK")
-    @JsonProperty(JSON_DISK)
-    private Double disk = null;
-
-    @Column(name = "FPGA")
-    @JsonProperty(JSON_FPGA)
-    private Integer fpga = null;
-
-    @Column(name = "GPU")
-    @JsonProperty(JSON_GPU)
-    private Integer gpu = null;
-
-    @ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
-    @JsonProperty(JSON_LOCATION)
-    private Location location = null;
-
-    @Column(name = "STATE")
-    @Enumerated(EnumType.STRING)
-    @JsonProperty(JSON_STATE)
-    private DiscoveryItemState state = null;
-
-    @Column(name = "OWNER")
-    @JsonProperty(JSON_OWNER)
-    private String owner = null;
-
     /**
      * Sets the FPGA field based on the cloud provider and machine type.
      * @param cloudProvider The type of the cloud provider (as a CloudProviderType enum).
@@ -249,37 +255,31 @@ public class Hardware implements Serializable {
     }
 
     /**
-     * Custom toString() method for the Hardware class to format the output
+     * Custom toString() method for the Hardware class to format the output.
+     * This method creates a formatted string representation of the Hardware object.
+     * It uses a map of field names (represented as JSON constants) and their corresponding values
+     * to build a human-readable string. The method leverages the {@link ModelUtils#buildToString}
+     * utility method to generate the string, ensuring that all fields are included with proper formatting.
+     *
+     * @return A formatted string representation of the Hardware object, with each field on a new line.
      */
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("class Hardware {\n");
+        Map<String, Object> fields = new LinkedHashMap<>();
+        fields.put(JSON_ID, id);
+        fields.put(JSON_NAME, name);
+        fields.put(JSON_PROVIDER_ID, providerId);
+        fields.put(JSON_CORES, cores);
+        fields.put(JSON_CPU_FREQUENCY, cpuFrequency);
+        fields.put(JSON_RAM, ram);
+        fields.put(JSON_DISK, disk);
+        fields.put(JSON_FPGA, fpga);
+        fields.put(JSON_GPU, gpu);
+        fields.put(JSON_LOCATION, location);
+        fields.put(JSON_STATE, state);
+        fields.put(JSON_OWNER, owner);
 
-        sb.append("    ").append(JSON_ID).append(": ").append(toIndentedString(id)).append("\n");
-        sb.append("    ").append(JSON_NAME).append(": ").append(toIndentedString(name)).append("\n");
-        sb.append("    ").append(JSON_PROVIDER_ID).append(": ").append(toIndentedString(providerId)).append("\n");
-        sb.append("    ").append(JSON_CORES).append(": ").append(toIndentedString(cores)).append("\n");
-        sb.append("    ").append(JSON_CPU_FREQUENCY).append(": ").append(toIndentedString(cpuFrequency)).append("\n");
-        sb.append("    ").append(JSON_RAM).append(": ").append(toIndentedString(ram)).append("\n");
-        sb.append("    ").append(JSON_DISK).append(": ").append(toIndentedString(disk)).append("\n");
-        sb.append("    ").append(JSON_FPGA).append(": ").append(toIndentedString(fpga)).append("\n");
-        sb.append("    ").append(JSON_GPU).append(": ").append(toIndentedString(gpu)).append("\n");
-        sb.append("    ").append(JSON_LOCATION).append(": ").append(toIndentedString(location)).append("\n");
-        sb.append("    ").append(JSON_STATE).append(": ").append(toIndentedString(state)).append("\n");
-        sb.append("    ").append(JSON_OWNER).append(": ").append(toIndentedString(owner)).append("\n");
-        sb.append("}");
-        return sb.toString();
+        return ModelUtils.buildToString(CLASS_NAME, fields);
     }
 
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
-    }
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/Hardware.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/Hardware.java
@@ -37,8 +37,6 @@ import lombok.experimental.Accessors;
 @Entity
 @Table(name = "HARDWARE")
 public class Hardware implements Serializable {
-    // Class name constant
-    public static final String CLASS_NAME = "Hardware";
 
     // JSON property constants
     public static final String JSON_ID = "id";
@@ -255,8 +253,8 @@ public class Hardware implements Serializable {
     }
 
     /**
-     * Custom toString() method for the Hardware class to format the output.
-     * This method creates a formatted string representation of the Hardware object.
+     * Custom toString() method for the class to format the output.
+     * This method creates a formatted string representation of the class object.
      * It uses a map of field names (represented as JSON constants) and their corresponding values
      * to build a human-readable string. The method leverages the {@link ModelUtils#buildToString}
      * utility method to generate the string, ensuring that all fields are included with proper formatting.
@@ -279,7 +277,7 @@ public class Hardware implements Serializable {
         fields.put(JSON_STATE, state);
         fields.put(JSON_OWNER, owner);
 
-        return ModelUtils.buildToString(CLASS_NAME, fields);
+        return ModelUtils.buildToString(getClass().getSimpleName(), fields);
     }
 
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/IaasDefinition.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/IaasDefinition.java
@@ -20,15 +20,23 @@ import lombok.*;
 @ToString(callSuper = true)
 public class IaasDefinition {
 
-    @JsonProperty("nodeName")
+    public static final String JSON_NODE_NAME = "nodeName";
+
+    public static final String JSON_TASK_NAME = "taskName";
+
+    public static final String JSON_NODE_CANDIDATE_ID = "nodeCandidateId";
+
+    public static final String JSON_CLOUD_ID = "cloudId";
+
+    @JsonProperty(JSON_NODE_NAME)
     private String name = null;
 
-    @JsonProperty("taskName")
+    @JsonProperty(JSON_TASK_NAME)
     private String taskName = null;
 
-    @JsonProperty("nodeCandidateId")
+    @JsonProperty(JSON_NODE_CANDIDATE_ID)
     private String nodeCandidateId = null;
 
-    @JsonProperty("cloudId")
+    @JsonProperty(JSON_CLOUD_ID)
     private String cloudId = null;
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/IaasNode.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/IaasNode.java
@@ -7,11 +7,12 @@ package org.ow2.proactive.sal.model;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
-import org.ow2.proactive.sal.util.ModelUtils;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Table;
+
+import org.ow2.proactive.sal.util.ModelUtils;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -20,6 +21,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
 
 @AllArgsConstructor
 @NoArgsConstructor

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/IaasNode.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/IaasNode.java
@@ -5,7 +5,9 @@
  */
 package org.ow2.proactive.sal.model;
 
-import java.util.Objects;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.ow2.proactive.sal.util.ModelUtils;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -14,73 +16,61 @@ import javax.persistence.Table;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
 @Getter
 @Setter
+@EqualsAndHashCode(callSuper = true) // Includes `id` from AbstractNode
 @Table(name = "IAAS_NODE")
 public class IaasNode extends AbstractNode {
 
+    // JSON field constants
+    public static final String JSON_NUM_DEPLOYMENTS = "numDeployments";
+
     @Column(name = "NUM_DEPLOYMENTS")
-    @JsonProperty("numDeployments")
+    @JsonProperty(JSON_NUM_DEPLOYMENTS)
     private Long numDeployments = 0L;
 
+    /**
+     * Increment the number of deployed nodes.
+     *
+     * @param number The number to increment.
+     */
     public void incDeployedNodes(Long number) {
         numDeployments = numDeployments + number;
     }
 
+    /**
+     * Decrement the number of deployed nodes, ensuring it doesn't drop below 0.
+     *
+     * @param number The number to decrement.
+     */
     public void decDeployedNodes(Long number) {
         numDeployments = numDeployments > number ? numDeployments - number : 0L;
     }
 
+    /**
+     * Constructor to create an IaasNode from a NodeCandidate.
+     *
+     * @param nodeCandidate The node candidate to initialize from.
+     */
     public IaasNode(NodeCandidate nodeCandidate) {
         this.nodeCandidate = nodeCandidate;
         nodeCandidate.setNodeId(this.id);
     }
 
     @Override
-    public boolean equals(java.lang.Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        IaasNode iaasNode = (IaasNode) o;
-        return Objects.equals(this.id, iaasNode.id) && Objects.equals(this.nodeCandidate, iaasNode.nodeCandidate) &&
-               Objects.equals(this.numDeployments, iaasNode.numDeployments);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, nodeCandidate, numDeployments);
-    }
-
-    @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("class IaasNode {\n");
-        sb.append("    id: ").append(toIndentedString(id)).append("\n");
-        sb.append("    nodeCandidate: ").append(toIndentedString(nodeCandidate)).append("\n");
-        sb.append("    numDeployments: ").append(toIndentedString(numDeployments)).append("\n");
-        sb.append("}");
-        return sb.toString();
-    }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(java.lang.Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
+        Map<String, Object> fields = new LinkedHashMap<>();
+        fields.put(AbstractNode.JSON_ID, id);
+        fields.put(AbstractNode.JSON_NODE_CANDIDATE, nodeCandidate);
+        fields.put(JSON_NUM_DEPLOYMENTS, numDeployments);
+        return ModelUtils.buildToString(getClass().getSimpleName(), fields);
     }
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/Image.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/Image.java
@@ -6,9 +6,11 @@
 package org.ow2.proactive.sal.model;
 
 import java.io.Serializable;
-import java.util.Objects;
 
 import javax.persistence.*;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.ow2.proactive.sal.util.ModelUtils;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -81,28 +83,14 @@ public class Image implements Serializable {
      */
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("class Image {\n");
-
-        sb.append("    id: ").append(toIndentedString(id)).append("\n");
-        sb.append("    name: ").append(toIndentedString(name)).append("\n");
-        sb.append("    providerId: ").append(toIndentedString(providerId)).append("\n");
-        sb.append("    operatingSystem: ").append(toIndentedString(operatingSystem)).append("\n");
-        sb.append("    location: ").append(toIndentedString(location)).append("\n");
-        sb.append("    state: ").append(toIndentedString(state)).append("\n");
-        sb.append("    owner: ").append(toIndentedString(owner)).append("\n");
-        sb.append("}");
-        return sb.toString();
-    }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
+        Map<String, Object> fields = new LinkedHashMap<>();
+        fields.put(JSON_ID, id);
+        fields.put(JSON_NAME, name);
+        fields.put(JSON_PROVIDER_ID, providerId);
+        fields.put(JSON_OPERATING_SYSTEM, operatingSystem);
+        fields.put(JSON_LOCATION, location);
+        fields.put(JSON_STATE, state);
+        fields.put(JSON_OWNER, owner);
+        return ModelUtils.buildToString(getClass().getSimpleName(), fields);
     }
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/Image.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/Image.java
@@ -6,10 +6,11 @@
 package org.ow2.proactive.sal.model;
 
 import java.io.Serializable;
-
-import javax.persistence.*;
 import java.util.LinkedHashMap;
 import java.util.Map;
+
+import javax.persistence.*;
+
 import org.ow2.proactive.sal.util.ModelUtils;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -34,6 +35,8 @@ import lombok.experimental.Accessors;
 @Entity
 @Table(name = "IMAGE")
 public class Image implements Serializable {
+
+    // JSON property constants
     public static final String JSON_ID = "id";
 
     public static final String JSON_NAME = "name";
@@ -79,7 +82,13 @@ public class Image implements Serializable {
     private String owner = null;
 
     /**
-     * Custom toString() method for the Image class to format the output
+     * Custom toString() method for the class to format the output.
+     * This method creates a formatted string representation of the class object.
+     * It uses a map of field names (represented as JSON constants) and their corresponding values
+     * to build a human-readable string. The method leverages the {@link ModelUtils#buildToString}
+     * utility method to generate the string, ensuring that all fields are included with proper formatting.
+     *
+     * @return A formatted string representation of the Hardware object, with each field on a new line.
      */
     @Override
     public String toString() {

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/IpAddress.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/IpAddress.java
@@ -8,12 +8,13 @@ package org.ow2.proactive.sal.model;
 import java.io.Serializable;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import org.ow2.proactive.sal.util.ModelUtils;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+
+import org.ow2.proactive.sal.util.ModelUtils;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -23,6 +24,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.Accessors;
+
 
 /**
  * IpAddress
@@ -38,7 +40,9 @@ public class IpAddress implements Serializable {
 
     // JSON field constants
     public static final String JSON_IP_ADDRESS_TYPE = "IpAddressType";
+
     public static final String JSON_IP_VERSION = "IpVersion";
+
     public static final String JSON_VALUE = "value";
 
     @Column(name = "IP_ADDRESS_TYPE")

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/IpAddress.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/IpAddress.java
@@ -6,7 +6,9 @@
 package org.ow2.proactive.sal.model;
 
 import java.io.Serializable;
-import java.util.Objects;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.ow2.proactive.sal.util.ModelUtils;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
@@ -14,124 +16,51 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.sun.istack.NotNull;
 
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
-
+import lombok.Setter;
+import lombok.experimental.Accessors;
 
 /**
  * IpAddress
  */
 @AllArgsConstructor
 @NoArgsConstructor
+@Getter
+@Setter
+@Accessors(chain = true)
+@EqualsAndHashCode
 @Embeddable
 public class IpAddress implements Serializable {
+
+    // JSON field constants
+    public static final String JSON_IP_ADDRESS_TYPE = "IpAddressType";
+    public static final String JSON_IP_VERSION = "IpVersion";
+    public static final String JSON_VALUE = "value";
+
     @Column(name = "IP_ADDRESS_TYPE")
     @Enumerated(EnumType.STRING)
-    @JsonProperty("IpAddressType")
+    @JsonProperty(JSON_IP_ADDRESS_TYPE)
     private IpAddressType ipAddressType = null;
 
     @Column(name = "IP_VERSION")
     @Enumerated(EnumType.STRING)
-    @JsonProperty("IpVersion")
+    @JsonProperty(JSON_IP_VERSION)
     private IpVersion ipVersion = null;
 
     @Column(name = "VALUE")
-    @JsonProperty("value")
+    @JsonProperty(JSON_VALUE)
     private String value = null;
-
-    public IpAddress ipAddressType(IpAddressType ipAddressType) {
-        this.ipAddressType = ipAddressType;
-        return this;
-    }
-
-    /**
-     * Get ipAddressType
-     * @return ipAddressType
-     **/
-    @NotNull
-    public IpAddressType getIpAddressType() {
-        return ipAddressType;
-    }
-
-    public void setIpAddressType(IpAddressType ipAddressType) {
-        this.ipAddressType = ipAddressType;
-    }
-
-    public IpAddress ipVersion(IpVersion ipVersion) {
-        this.ipVersion = ipVersion;
-        return this;
-    }
-
-    /**
-     * Get ipVersion
-     * @return ipVersion
-     **/
-    @NotNull
-    public IpVersion getIpVersion() {
-        return ipVersion;
-    }
-
-    public void setIpVersion(IpVersion ipVersion) {
-        this.ipVersion = ipVersion;
-    }
-
-    public IpAddress value(String value) {
-        this.value = value;
-        return this;
-    }
-
-    /**
-     * the ip address value
-     * @return value
-     **/
-    public String getValue() {
-        return value;
-    }
-
-    public void setValue(String value) {
-        this.value = value;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        IpAddress ipAddress = (IpAddress) o;
-        return Objects.equals(this.ipAddressType, ipAddress.ipAddressType) &&
-               Objects.equals(this.ipVersion, ipAddress.ipVersion) && Objects.equals(this.value, ipAddress.value);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(ipAddressType, ipVersion, value);
-    }
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("class IpAddress {\n");
-
-        sb.append("    ipAddressType: ").append(toIndentedString(ipAddressType)).append("\n");
-        sb.append("    ipVersion: ").append(toIndentedString(ipVersion)).append("\n");
-        sb.append("    value: ").append(toIndentedString(value)).append("\n");
-        sb.append("}");
-        return sb.toString();
-    }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
+        Map<String, Object> fields = new LinkedHashMap<>();
+        fields.put(JSON_IP_ADDRESS_TYPE, ipAddressType);
+        fields.put(JSON_IP_VERSION, ipVersion);
+        fields.put(JSON_VALUE, value);
+        return ModelUtils.buildToString(getClass().getSimpleName(), fields);
     }
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/IpAddressType.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/IpAddressType.java
@@ -18,7 +18,7 @@ public enum IpAddressType {
 
     PRIVATE_IP("PRIVATE_IP");
 
-    private String value;
+    private final String value;
 
     IpAddressType(String value) {
         this.value = value;

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/IpVersion.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/IpVersion.java
@@ -18,7 +18,7 @@ public enum IpVersion {
 
     V6("V6");
 
-    private String value;
+    private final String value;
 
     IpVersion(String value) {
         this.value = value;

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/JobDefinition.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/JobDefinition.java
@@ -12,9 +12,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.*;
 
-
 /**
- * Attributes defining a Job`
+ * Attributes defining a Job
  */
 @AllArgsConstructor
 @NoArgsConstructor
@@ -23,12 +22,17 @@ import lombok.*;
 @ToString(callSuper = true)
 public class JobDefinition implements Serializable {
 
-    @JsonProperty("communications")
+    // JSON field constants
+    public static final String JSON_COMMUNICATIONS = "communications";
+    public static final String JSON_JOB_INFORMATION = "jobInformation";
+    public static final String JSON_TASKS = "tasks";
+
+    @JsonProperty(JSON_COMMUNICATIONS)
     private List<Communication> communications;
 
-    @JsonProperty("jobInformation")
+    @JsonProperty(JSON_JOB_INFORMATION)
     private JobInformation jobInformation;
 
-    @JsonProperty("tasks")
+    @JsonProperty(JSON_TASKS)
     private List<TaskDefinition> tasks;
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/JobDefinition.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/JobDefinition.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.*;
 
+
 /**
  * Attributes defining a Job
  */
@@ -24,7 +25,9 @@ public class JobDefinition implements Serializable {
 
     // JSON field constants
     public static final String JSON_COMMUNICATIONS = "communications";
+
     public static final String JSON_JOB_INFORMATION = "jobInformation";
+
     public static final String JSON_TASKS = "tasks";
 
     @JsonProperty(JSON_COMMUNICATIONS)

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/JobInformation.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/JobInformation.java
@@ -11,9 +11,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.*;
 
-
 /**
- * Attributes defining Job information`
+ * Attributes defining Job information
  */
 @AllArgsConstructor
 @NoArgsConstructor
@@ -22,9 +21,13 @@ import lombok.*;
 @ToString(callSuper = true)
 public class JobInformation implements Serializable {
 
-    @JsonProperty("id")
+    // JSON field constants
+    public static final String JSON_ID = "id";
+    public static final String JSON_NAME = "name";
+
+    @JsonProperty(JSON_ID)
     private String id;
 
-    @JsonProperty("name")
+    @JsonProperty(JSON_NAME)
     private String name;
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/JobInformation.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/JobInformation.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.*;
 
+
 /**
  * Attributes defining Job information
  */
@@ -23,6 +24,7 @@ public class JobInformation implements Serializable {
 
     // JSON field constants
     public static final String JSON_ID = "id";
+
     public static final String JSON_NAME = "name";
 
     @JsonProperty(JSON_ID)

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/Location.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/Location.java
@@ -6,9 +6,13 @@
 package org.ow2.proactive.sal.model;
 
 import java.io.Serializable;
+import java.util.LinkedHashMap;
 import java.util.Locale;
+import java.util.Map;
 
 import javax.persistence.*;
+
+import org.ow2.proactive.sal.util.ModelUtils;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -74,7 +78,7 @@ public class Location implements Serializable {
         ZONE("ZONE"),
         HOST("HOST");
 
-        private String value;
+        private final String value;
 
         LocationScopeEnum(String value) {
             this.value = value;
@@ -123,32 +127,27 @@ public class Location implements Serializable {
     @JsonProperty(JSON_OWNER)
     private String owner = null;
 
+    /**
+     * Custom toString() method for the class to format the output.
+     * This method creates a formatted string representation of the class object.
+     * It uses a map of field names (represented as JSON constants) and their corresponding values
+     * to build a human-readable string. The method leverages the {@link ModelUtils#buildToString}
+     * utility method to generate the string, ensuring that all fields are included with proper formatting.
+     *
+     * @return A formatted string representation of the Hardware object, with each field on a new line.
+     */
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("class Location {\n");
-
-        sb.append("    id: ").append(toIndentedString(id)).append("\n");
-        sb.append("    name: ").append(toIndentedString(name)).append("\n");
-        sb.append("    providerId: ").append(toIndentedString(providerId)).append("\n");
-        sb.append("    locationScope: ").append(toIndentedString(locationScope)).append("\n");
-        sb.append("    isAssignable: ").append(toIndentedString(isAssignable)).append("\n");
-        sb.append("    geoLocation: ").append(toIndentedString(geoLocation)).append("\n");
-        sb.append("    parent: ").append(toIndentedString(parent)).append("\n");
-        sb.append("    state: ").append(toIndentedString(state)).append("\n");
-        sb.append("    owner: ").append(toIndentedString(owner)).append("\n");
-        sb.append("}");
-        return sb.toString();
-    }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
+        Map<String, Object> fields = new LinkedHashMap<>();
+        fields.put(JSON_ID, id);
+        fields.put(JSON_NAME, name);
+        fields.put(JSON_PROVIDER_ID, providerId);
+        fields.put(JSON_LOCATION_SCOPE, locationScope);
+        fields.put(JSON_IS_ASSIGNABLE, isAssignable);
+        fields.put(JSON_GEO_LOCATION, geoLocation);
+        fields.put(JSON_PARENT, parent);
+        fields.put(JSON_STATE, state);
+        fields.put(JSON_OWNER, owner);
+        return ModelUtils.buildToString(getClass().getSimpleName(), fields);
     }
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/LoginCredential.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/LoginCredential.java
@@ -6,8 +6,12 @@
 package org.ow2.proactive.sal.model;
 
 import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import javax.persistence.Embeddable;
+
+import org.ow2.proactive.sal.util.ModelUtils;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -45,38 +49,21 @@ public class LoginCredential implements Serializable {
     @JsonProperty(JSON_PRIVATE_KEY)
     private String privateKey = null;
 
+    /**
+     * Custom toString() method for the class to format the output.
+     * This method creates a formatted string representation of the class object.
+     * It uses a map of field names (represented as JSON constants) and their corresponding values
+     * to build a human-readable string. The method leverages the {@link ModelUtils#buildToString}
+     * utility method to generate the string, ensuring that all fields are included with proper formatting.
+     *
+     * @return A formatted string representation of the Hardware object, with each field on a new line.
+     */
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("class LoginCredential {\n");
-
-        sb.append("    ")
-          .append(LoginCredential.JSON_USERNAME)
-          .append(": ")
-          .append(toIndentedString(username))
-          .append("\n");
-        sb.append("    ")
-          .append(LoginCredential.JSON_PASSWORD)
-          .append(": ")
-          .append(toIndentedString(password))
-          .append("\n");
-        sb.append("    ")
-          .append(LoginCredential.JSON_PRIVATE_KEY)
-          .append(": ")
-          .append(toIndentedString(privateKey))
-          .append("\n");
-        sb.append("}");
-        return sb.toString();
-    }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
+        Map<String, Object> fields = new LinkedHashMap<>();
+        fields.put(JSON_USERNAME, username);
+        fields.put(JSON_PASSWORD, password);
+        fields.put(JSON_PRIVATE_KEY, privateKey);
+        return ModelUtils.buildToString(getClass().getSimpleName(), fields);
     }
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/NodeCandidate.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/NodeCandidate.java
@@ -6,11 +6,14 @@
 package org.ow2.proactive.sal.model;
 
 import java.io.Serializable;
+import java.util.LinkedHashMap;
 import java.util.Locale;
+import java.util.Map;
 
 import javax.persistence.*;
 
 import org.hibernate.annotations.GenericGenerator;
+import org.ow2.proactive.sal.util.ModelUtils;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -83,7 +86,7 @@ public class NodeCandidate implements Serializable {
         EDGE("EDGE"),
         SIMULATION("SIMULATION");
 
-        private String value;
+        private final String value;
 
         NodeCandidateTypeEnum(String value) {
             this.value = value;
@@ -173,36 +176,32 @@ public class NodeCandidate implements Serializable {
         return nodeCandidateType.equals(NodeCandidateTypeEnum.EDGE);
     }
 
+    /**
+     * Custom toString() method for the class to format the output.
+     * This method creates a formatted string representation of the class object.
+     * It uses a map of field names (represented as JSON constants) and their corresponding values
+     * to build a human-readable string. The method leverages the {@link ModelUtils#buildToString}
+     * utility method to generate the string, ensuring that all fields are included with proper formatting.
+     *
+     * @return A formatted string representation of the Hardware object, with each field on a new line.
+     */
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("class NodeCandidate {\n");
+        Map<String, Object> fields = new LinkedHashMap<>();
+        fields.put(JSON_ID, id);
+        fields.put(JSON_NODE_CANDIDATE_TYPE, nodeCandidateType);
+        fields.put(JSON_JOB_ID_FOR_BYON, jobIdForBYON);
+        fields.put(JSON_JOB_ID_FOR_EDGE, jobIdForEDGE);
+        fields.put(JSON_PRICE, price);
+        fields.put(JSON_CLOUD, cloud);
+        fields.put(JSON_LOCATION, location);
+        fields.put(JSON_IMAGE, image);
+        fields.put(JSON_HARDWARE, hardware);
+        fields.put(JSON_PRICE_PER_INVOCATION, pricePerInvocation);
+        fields.put(JSON_MEMORY_PRICE, memoryPrice);
+        fields.put(JSON_NODE_ID, nodeId);
+        fields.put(JSON_ENVIRONMENT, environment);
 
-        sb.append("    id: ").append(toIndentedString(id)).append("\n");
-        sb.append("    nodeCandidateType: ").append(toIndentedString(nodeCandidateType)).append("\n");
-        sb.append("    jobIdForBYON: ").append(toIndentedString(jobIdForBYON)).append("\n");
-        sb.append("    jobIdForEDGE: ").append(toIndentedString(jobIdForEDGE)).append("\n");
-        sb.append("    price: ").append(toIndentedString(price)).append("\n");
-        sb.append("    cloud: ").append(toIndentedString(cloud)).append("\n");
-        sb.append("    image: ").append(toIndentedString(image)).append("\n");
-        sb.append("    hardware: ").append(toIndentedString(hardware)).append("\n");
-        sb.append("    location: ").append(toIndentedString(location)).append("\n");
-        sb.append("    pricePerInvocation: ").append(toIndentedString(pricePerInvocation)).append("\n");
-        sb.append("    memoryPrice: ").append(toIndentedString(memoryPrice)).append("\n");
-        sb.append("    nodeId: ").append(toIndentedString(nodeId)).append("\n");
-        sb.append("    environment: ").append(toIndentedString(environment)).append("\n");
-        sb.append("}");
-        return sb.toString();
-    }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
+        return ModelUtils.buildToString(getClass().getSimpleName(), fields);
     }
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/NodeProperties.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/NodeProperties.java
@@ -6,10 +6,13 @@
 package org.ow2.proactive.sal.model;
 
 import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
-import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.Embedded;
+
+import org.ow2.proactive.sal.util.ModelUtils;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -67,54 +70,28 @@ public class NodeProperties implements Serializable {
     private GeoLocation geoLocation = null;
 
     /**
-     * Custom toString method with indentation and field labels.
-     * It creates a more readable string output for debugging and logging.
+     * Custom toString() method for the class to format the output.
+     * This method creates a formatted string representation of the class object.
+     * It uses a map of field names (represented as JSON constants) and their corresponding values
+     * to build a human-readable string. The method leverages the {@link ModelUtils#buildToString}
+     * utility method to generate the string, ensuring that all fields are included with proper formatting.
      *
-     * @return a string representation of the NodeProperties instance.
+     * @return A formatted string representation of the Hardware object, with each field on a new line.
      */
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("NodeProperties {\n");
-        sb.append("    ")
-          .append(Hardware.JSON_PROVIDER_ID)
-          .append(": ")
-          .append(toIndentedString(providerId))
-          .append("\n");
-        sb.append("    ").append(NodeCandidate.JSON_PRICE).append(": ").append(toIndentedString(price)).append("\n");
-        sb.append("    ").append(Hardware.JSON_CORES).append(": ").append(toIndentedString(cores)).append("\n");
-        sb.append("    ")
-          .append(Hardware.JSON_CPU_FREQUENCY)
-          .append(": ")
-          .append(toIndentedString(cpuFrequency))
-          .append("\n");
-        sb.append("    ").append(Hardware.JSON_RAM).append(": ").append(toIndentedString(ram)).append("\n");
-        sb.append("    ").append(Hardware.JSON_DISK).append(": ").append(toIndentedString(disk)).append("\n");
-        sb.append("    ").append(Hardware.JSON_FPGA).append(": ").append(toIndentedString(fpga)).append("\n");
-        sb.append("    ").append(Hardware.JSON_GPU).append(": ").append(toIndentedString(gpu)).append("\n");
-        sb.append("    ")
-          .append(Image.JSON_OPERATING_SYSTEM)
-          .append(": ")
-          .append(toIndentedString(operatingSystem))
-          .append("\n");
-        sb.append("    ")
-          .append(Location.JSON_GEO_LOCATION)
-          .append(": ")
-          .append(toIndentedString(geoLocation))
-          .append("\n");
-        sb.append("}");
-        return sb.toString();
-    }
+        Map<String, Object> fields = new LinkedHashMap<>();
+        fields.put(Hardware.JSON_PROVIDER_ID, providerId);
+        fields.put(NodeCandidate.JSON_PRICE, price);
+        fields.put(Hardware.JSON_CORES, cores);
+        fields.put(Hardware.JSON_CPU_FREQUENCY, cpuFrequency);
+        fields.put(Hardware.JSON_RAM, ram);
+        fields.put(Hardware.JSON_DISK, disk);
+        fields.put(Hardware.JSON_FPGA, fpga);
+        fields.put(Hardware.JSON_GPU, gpu);
+        fields.put(Image.JSON_OPERATING_SYSTEM, operatingSystem);
+        fields.put(Location.JSON_GEO_LOCATION, geoLocation);
 
-    /**
-     * Helper method to convert objects to indented strings.
-     * @param obj The object to convert.
-     * @return A string representation of the object or "null" if the object is null.
-     */
-    private String toIndentedString(Object obj) {
-        if (obj == null) {
-            return "null";
-        }
-        return obj.toString().replace("\n", "\n    ");
+        return ModelUtils.buildToString(getClass().getSimpleName(), fields);
     }
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/NodeTypeRequirement.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/NodeTypeRequirement.java
@@ -5,12 +5,16 @@
  */
 package org.ow2.proactive.sal.model;
 
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Objects;
+import java.util.Map;
+
+import org.ow2.proactive.sal.util.ModelUtils;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -20,15 +24,26 @@ import lombok.Setter;
  */
 @Getter
 @Setter
-@JsonTypeName(value = "NodeTypeRequirement")
+@EqualsAndHashCode(callSuper = true)
+@JsonTypeName(value = NodeTypeRequirement.CLASS_NAME)
 public class NodeTypeRequirement extends Requirement {
-    @JsonProperty("nodeTypes")
+    // Define class name constant for reuse
+    public static final String CLASS_NAME = "NodeTypeRequirement";
+
+    // JSON property constants
+    public static final String JSON_NODE_TYPES = "nodeTypes";
+
+    public static final String JSON_JOB_ID_FOR_BYON = "jobIdForBYON";
+
+    public static final String JSON_JOB_ID_FOR_EDGE = "jobIdForEDGE";
+
+    @JsonProperty(JSON_NODE_TYPES)
     private List<NodeType> nodeTypes;
 
-    @JsonProperty("jobIdForByon")
+    @JsonProperty(JSON_JOB_ID_FOR_BYON)
     private String jobIdForBYON;
 
-    @JsonProperty("jobIdForEDGE")
+    @JsonProperty(JSON_JOB_ID_FOR_EDGE)
     private String jobIdForEDGE;
 
     public NodeTypeRequirement() {
@@ -43,49 +58,18 @@ public class NodeTypeRequirement extends Requirement {
     }
 
     /**
-     * Get nodeType
-     * @return nodeType
-     **/
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        NodeTypeRequirement nodeTypeRequirement = (NodeTypeRequirement) o;
-        return Objects.equals(this.nodeTypes, nodeTypeRequirement.nodeTypes) &&
-               Objects.equals(this.jobIdForBYON, nodeTypeRequirement.jobIdForBYON) &&
-               Objects.equals(this.jobIdForEDGE, nodeTypeRequirement.jobIdForEDGE) && super.equals(o);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(nodeTypes, jobIdForBYON, jobIdForEDGE, super.hashCode());
-    }
-
+     * Custom toString() method for the NodeTypeRequirement class to format the output.
+     * This method uses {@link ModelUtils#buildToString} to generate the string representation of the object.
+     * @return A formatted string representation of the NodeTypeRequirement object.
+     */
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("class NodeTypeRequirement {\n");
-        sb.append("    ").append(toIndentedString(super.toString())).append("\n");
-        sb.append("    nodeType: ").append(toIndentedString(nodeTypes)).append("\n");
-        sb.append("    jobIdForBYON: ").append(toIndentedString(jobIdForBYON)).append("\n");
-        sb.append("    jobIdForEDGE: ").append(toIndentedString(jobIdForEDGE)).append("\n");
-        sb.append("}");
-        return sb.toString();
+        Map<String, Object> fields = new LinkedHashMap<>();
+        fields.put(JSON_NODE_TYPES, nodeTypes);
+        fields.put(JSON_JOB_ID_FOR_BYON, jobIdForBYON);
+        fields.put(JSON_JOB_ID_FOR_EDGE, jobIdForEDGE);
+
+        return ModelUtils.buildToString(CLASS_NAME, fields);
     }
 
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
-    }
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/OperatingSystem.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/OperatingSystem.java
@@ -7,17 +7,23 @@ package org.ow2.proactive.sal.model;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
-import java.util.Objects;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 
+import org.ow2.proactive.sal.util.ModelUtils;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 
 /**
@@ -25,114 +31,49 @@ import lombok.NoArgsConstructor;
  */
 @AllArgsConstructor
 @NoArgsConstructor
+@Getter
+@Setter
 @Embeddable
+@EqualsAndHashCode
 public class OperatingSystem implements Serializable {
+
+    // JSON property names as constants
+    public static final String JSON_OPERATING_SYSTEM_FAMILY = "operatingSystemFamily";
+
+    public static final String JSON_OPERATING_SYSTEM_ARCHITECTURE = "operatingSystemArchitecture";
+
+    public static final String JSON_OPERATING_SYSTEM_VERSION = "operatingSystemVersion";
+
     @Column(name = "OPERATING_SYSTEM_FAMILY")
     @Enumerated(EnumType.STRING)
-    @JsonProperty("operatingSystemFamily")
+    @JsonProperty(JSON_OPERATING_SYSTEM_FAMILY)
     private OperatingSystemFamily operatingSystemFamily = null;
 
     @Column(name = "OPERATING_SYSTEM_ARCHITECTURE")
     @Enumerated(EnumType.STRING)
-    @JsonProperty("operatingSystemArchitecture")
+    @JsonProperty(JSON_OPERATING_SYSTEM_ARCHITECTURE)
     private OperatingSystemArchitecture operatingSystemArchitecture = null;
 
     @Column(name = "OPERATING_SYSTEM_VERSION")
-    @JsonProperty("operatingSystemVersion")
+    @JsonProperty(JSON_OPERATING_SYSTEM_VERSION)
     private BigDecimal operatingSystemVersion = null;
 
-    public OperatingSystem operatingSystemFamily(OperatingSystemFamily operatingSystemFamily) {
-        this.operatingSystemFamily = operatingSystemFamily;
-        return this;
-    }
-
     /**
-     * Get operatingSystemFamily
-     * @return operatingSystemFamily
-     **/
-    public OperatingSystemFamily getOperatingSystemFamily() {
-        return operatingSystemFamily;
-    }
-
-    public void setOperatingSystemFamily(OperatingSystemFamily operatingSystemFamily) {
-        this.operatingSystemFamily = operatingSystemFamily;
-    }
-
-    public OperatingSystem operatingSystemArchitecture(OperatingSystemArchitecture operatingSystemArchitecture) {
-        this.operatingSystemArchitecture = operatingSystemArchitecture;
-        return this;
-    }
-
-    /**
-     * Get operatingSystemArchitecture
-     * @return operatingSystemArchitecture
-     **/
-    public OperatingSystemArchitecture getOperatingSystemArchitecture() {
-        return operatingSystemArchitecture;
-    }
-
-    public void setOperatingSystemArchitecture(OperatingSystemArchitecture operatingSystemArchitecture) {
-        this.operatingSystemArchitecture = operatingSystemArchitecture;
-    }
-
-    public OperatingSystem operatingSystemVersion(BigDecimal operatingSystemVersion) {
-        this.operatingSystemVersion = operatingSystemVersion;
-        return this;
-    }
-
-    /**
-     * Version of the OS
-     * @return operatingSystemVersion
-     **/
-    public BigDecimal getOperatingSystemVersion() {
-        return operatingSystemVersion;
-    }
-
-    public void setOperatingSystemVersion(BigDecimal operatingSystemVersion) {
-        this.operatingSystemVersion = operatingSystemVersion;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        OperatingSystem operatingSystem = (OperatingSystem) o;
-        return Objects.equals(this.operatingSystemFamily, operatingSystem.operatingSystemFamily) &&
-               Objects.equals(this.operatingSystemArchitecture, operatingSystem.operatingSystemArchitecture) &&
-               Objects.equals(this.operatingSystemVersion, operatingSystem.operatingSystemVersion);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(operatingSystemFamily, operatingSystemArchitecture, operatingSystemVersion);
-    }
-
+     * Custom toString() method for the class to format the output.
+     * This method creates a formatted string representation of the class object.
+     * It uses a map of field names (represented as JSON constants) and their corresponding values
+     * to build a human-readable string. The method leverages the {@link ModelUtils#buildToString}
+     * utility method to generate the string, ensuring that all fields are included with proper formatting.
+     *
+     * @return A formatted string representation of the Hardware object, with each field on a new line.
+     */
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("class OperatingSystem {\n");
+        Map<String, Object> fields = new LinkedHashMap<>();
+        fields.put(JSON_OPERATING_SYSTEM_FAMILY, operatingSystemFamily);
+        fields.put(JSON_OPERATING_SYSTEM_ARCHITECTURE, operatingSystemArchitecture);
+        fields.put(JSON_OPERATING_SYSTEM_VERSION, operatingSystemVersion);
 
-        sb.append("    operatingSystemFamily: ").append(toIndentedString(operatingSystemFamily)).append("\n");
-        sb.append("    operatingSystemArchitecture: ")
-          .append(toIndentedString(operatingSystemArchitecture))
-          .append("\n");
-        sb.append("    operatingSystemVersion: ").append(toIndentedString(operatingSystemVersion)).append("\n");
-        sb.append("}");
-        return sb.toString();
-    }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
+        return ModelUtils.buildToString(getClass().getSimpleName(), fields);
     }
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/OperatingSystemType.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/OperatingSystemType.java
@@ -22,11 +22,16 @@ import lombok.*;
 @Setter
 @Embeddable
 public class OperatingSystemType implements Serializable {
+    // JSON property names as constants
+    public static final String JSON_OPERATING_SYSTEM_FAMILY = "operatingSystemFamily";
+
+    public static final String JSON_OPERATING_SYSTEM_VERSION = "operatingSystemVersion";
+
     @Column(name = "OPERATING_SYSTEM_FAMILY")
-    @JsonProperty("operatingSystemFamily")
+    @JsonProperty(JSON_OPERATING_SYSTEM_FAMILY)
     private String operatingSystemFamily;
 
     @Column(name = "OPERATING_SYSTEM_VERSION")
-    @JsonProperty("operatingSystemVersion")
+    @JsonProperty(JSON_OPERATING_SYSTEM_VERSION)
     private float operatingSystemVersion;
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/PACloud.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/PACloud.java
@@ -151,15 +151,19 @@ public class PACloud implements Serializable {
                                                                    .map(Deployment::getNodeName)
                                                                    .collect(Collectors.toList())
                                                                    .toString();
-        return "PACloud{" + "cloudId='" + cloudId + '\'' + ", nodeSourceNamePrefix='" + nodeSourceNamePrefix + '\'' +
-               ", cloudProvider='" + cloudProvider + '\'' + ", cloudType='" + cloudType.toString() + '\'' +
-               ", subnet='" + subnet + '\'' + ", securityGroup='" + securityGroup + '\'' + ", sshCredentials='" +
-               Optional.ofNullable(sshCredentials).map(SSHCredentials::toString).orElse(null) + '\'' + ", endpoint='" +
-               endpoint + '\'' + ", scopePrefix='" + scopePrefix + '\'' + ", scopeValue='" + scopeValue + '\'' +
-               ", identityVersion='" + identityVersion + '\'' + ", dummyInfrastructureName='" +
-               dummyInfrastructureName + '\'' + ", defaultNetwork='" + defaultNetwork + '\'' + ", blacklist='" +
-               blacklist + '\'' + ", deployedRegions=" + deployedRegions + ", deployedWhiteListedRegions=" +
-               deployedWhiteListedRegions + ", deployments='" + deploymentsPrint + '\'' + '}';
+        return getClass().getSimpleName() + "{" + CloudDefinition.JSON_CLOUD_ID + "='" + cloudId + '\'' + ", " +
+               CloudDefinition.JSON_CLOUD_PROVIDER_NAME + "='" + cloudProvider + '\'' + ", " +
+               CloudDefinition.JSON_CLOUD_TYPE + "='" + cloudType.toString() + '\'' + ", " +
+               CloudDefinition.JSON_SECURITY_GROUP + "='" + securityGroup + '\'' + ", " + CloudDefinition.JSON_SUBNET +
+               "='" + subnet + '\'' + ", " + CloudDefinition.JSON_SSH_CREDENTIALS + "='" +
+               Optional.ofNullable(sshCredentials).map(SSHCredentials::toString).orElse(null) + '\'' + ", " +
+               CloudDefinition.JSON_ENDPOINT + "='" + endpoint + '\'' + ", scopePrefix='" + scopePrefix + '\'' +
+               ", scopeValue='" + scopeValue + '\'' + ", " + CloudDefinition.JSON_IDENTITY_VERSION + "='" +
+               identityVersion + '\'' + ", dummyInfrastructureName='" + dummyInfrastructureName + '\'' + ", " +
+               CloudDefinition.JSON_DEFAULT_NETWORK + "='" + defaultNetwork + '\'' + ", " +
+               CloudDefinition.JSON_BLACKLIST + "='" + blacklist + '\'' + ", deployedRegions=" + deployedRegions +
+               ", deployedWhiteListedRegions=" + deployedWhiteListedRegions + ", deployments='" + deploymentsPrint +
+               '\'' + '}';
     }
 
     @PreRemove

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/PACloud.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/PACloud.java
@@ -35,8 +35,12 @@ public class PACloud implements Serializable {
     @Column(name = "NODE_SOURCE_NAME_PREFIX")
     private String nodeSourceNamePrefix;
 
-    @Column(name = "CLOUD_PROVIDER_NAME")
-    private String cloudProviderName;
+    //  @Column(name = "CLOUD_PROVIDER_NAME")
+    //  private String cloudProviderName;
+
+    @Column(name = "CLOUD_PROVIDER")
+    @Enumerated(EnumType.STRING)
+    private CloudProviderType cloudProvider;
 
     @Column(name = "CLOUD_TYPE")
     @Enumerated(EnumType.STRING)
@@ -151,7 +155,7 @@ public class PACloud implements Serializable {
                                                                    .collect(Collectors.toList())
                                                                    .toString();
         return "PACloud{" + "cloudId='" + cloudId + '\'' + ", nodeSourceNamePrefix='" + nodeSourceNamePrefix + '\'' +
-               ", cloudProviderName='" + cloudProviderName + '\'' + ", cloudType='" + cloudType.toString() + '\'' +
+               ", cloudProvider='" + cloudProvider + '\'' + ", cloudType='" + cloudType.toString() + '\'' +
                ", subnet='" + subnet + '\'' + ", securityGroup='" + securityGroup + '\'' + ", sshCredentials='" +
                Optional.ofNullable(sshCredentials).map(SSHCredentials::toString).orElse(null) + '\'' + ", endpoint='" +
                endpoint + '\'' + ", scopePrefix='" + scopePrefix + '\'' + ", scopeValue='" + scopeValue + '\'' +

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/PACloud.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/PACloud.java
@@ -23,7 +23,7 @@ import lombok.Setter;
 @Setter
 @Entity
 @Table(name = "PA_CLOUD")
-@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "cloudId", scope = PACloud.class)
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = CloudDefinition.JSON_CLOUD_ID, scope = PACloud.class)
 public class PACloud implements Serializable {
 
     public static final String WHITE_LISTED_NAME_PREFIX = "WLH";

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/PACloud.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/PACloud.java
@@ -35,9 +35,6 @@ public class PACloud implements Serializable {
     @Column(name = "NODE_SOURCE_NAME_PREFIX")
     private String nodeSourceNamePrefix;
 
-    //  @Column(name = "CLOUD_PROVIDER_NAME")
-    //  private String cloudProviderName;
-
     @Column(name = "CLOUD_PROVIDER")
     @Enumerated(EnumType.STRING)
     private CloudProviderType cloudProvider;

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/ReconfigurationJobDefinition.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/ReconfigurationJobDefinition.java
@@ -21,15 +21,24 @@ import lombok.*;
 @Data
 public class ReconfigurationJobDefinition implements Serializable {
 
-    @JsonProperty("communications")
+    // JSON field constants
+    public static final String JSON_COMMUNICATIONS = "communications";
+
+    public static final String JSON_UNCHANGED_TASKS = "unchangedTasks";
+
+    public static final String JSON_DELETE_TASKS = "deleteTasks";
+
+    public static final String JSON_ADD_TASKS = "addTasks";
+
+    @JsonProperty(JSON_COMMUNICATIONS)
     private List<Communication> communications;
 
-    @JsonProperty("unchangedTasks")
+    @JsonProperty(JSON_UNCHANGED_TASKS)
     private List<String> unchangedTasks;
 
-    @JsonProperty("deleteTasks")
+    @JsonProperty(JSON_DELETE_TASKS)
     private List<String> deletedTasks;
 
-    @JsonProperty("addTasks")
+    @JsonProperty(JSON_ADD_TASKS)
     private List<TaskReconfigurationDefinition> addedTasks;
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/Requirement.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/Requirement.java
@@ -5,11 +5,15 @@
  */
 package org.ow2.proactive.sal.model;
 
+import java.util.LinkedHashMap;
 import java.util.Locale;
-import java.util.Objects;
+import java.util.Map;
+
+import org.ow2.proactive.sal.util.ModelUtils;
 
 import com.fasterxml.jackson.annotation.*;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -19,19 +23,21 @@ import lombok.Setter;
  */
 @Getter
 @Setter
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", visible = true)
-@JsonSubTypes({ @JsonSubTypes.Type(value = AttributeRequirement.class, name = "AttributeRequirement"),
-                @JsonSubTypes.Type(value = NodeTypeRequirement.class, name = "NodeTypeRequirement"), })
-
+@EqualsAndHashCode
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = Requirement.JSON_TYPE, visible = true)
+@JsonSubTypes({ @JsonSubTypes.Type(value = AttributeRequirement.class, name = AttributeRequirement.CLASS_NAME),
+                @JsonSubTypes.Type(value = NodeTypeRequirement.class, name = NodeTypeRequirement.CLASS_NAME) })
 public abstract class Requirement {
 
-    /**
-     * Port type
-     */
-    enum RequirementType {
-        ATTRIBUTE("AttributeRequirement"),
+    // JSON property constants
+    public static final String JSON_TYPE = "type";
 
-        NODE_TYPE("NodeTypeRequirement");
+    /**
+     * Requirement type (can be ATTRIBUTE or NODE_TYPE)
+     */
+    public enum RequirementType {
+        ATTRIBUTE(AttributeRequirement.CLASS_NAME),
+        NODE_TYPE(NodeTypeRequirement.CLASS_NAME);
 
         private final String value;
 
@@ -56,44 +62,22 @@ public abstract class Requirement {
         }
     }
 
-    @JsonProperty("type")
+    @JsonProperty(JSON_TYPE)
     protected RequirementType type;
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Requirement requirement = (Requirement) o;
-        return Objects.equals(this.type, requirement.type);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(type);
-    }
-
+    /**
+     * Custom toString() method for the Requirement class to format the output.
+     * This method creates a formatted string representation of the Requirement object.
+     * It uses the type and other fields to build a human-readable string.
+     * The method leverages the {@link ModelUtils#buildToString} utility method to generate the string.
+     *
+     * @return A formatted string representation of the Requirement object, with each field on a new line.
+     */
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("class Requirement {\n");
+        Map<String, Object> fields = new LinkedHashMap<>();
+        fields.put(JSON_TYPE, type);
 
-        sb.append("    type: ").append(toIndentedString(type)).append("\n");
-        sb.append("}");
-        return sb.toString();
-    }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
+        return ModelUtils.buildToString(Requirement.class.getSimpleName(), fields);
     }
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/SSHCredentials.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/SSHCredentials.java
@@ -6,7 +6,6 @@
 package org.ow2.proactive.sal.model;
 
 import java.io.Serializable;
-import java.util.Objects;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
@@ -17,49 +16,42 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 
+/**
+ * Represents SSH credentials for cloud configuration
+ */
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @Setter
 @ToString
+@EqualsAndHashCode
 @Embeddable
 public class SSHCredentials implements Serializable {
 
+    // JSON field constants
+    public static final String JSON_USERNAME = "username";
+
+    public static final String JSON_KEY_PAIR_NAME = "keyPairName";
+
+    public static final String JSON_PUBLIC_KEY = "publicKey";
+
+    public static final String JSON_PRIVATE_KEY = "privateKey";
+
     @Column(name = "USERNAME")
-    @JsonProperty("username")
+    @JsonProperty(JSON_USERNAME)
     private String username = null;
 
     @Column(name = "KEY_PAIR_NAME")
-    @JsonProperty("keyPairName")
+    @JsonProperty(JSON_KEY_PAIR_NAME)
     private String keyPairName = null;
 
     @Lob
     @Column(name = "PUBLIC_KEY")
-    @JsonProperty("publicKey")
+    @JsonProperty(JSON_PUBLIC_KEY)
     private String publicKey = null;
 
     @Lob
     @Column(name = "PRIVATE_KEY")
-    @JsonProperty("privateKey")
+    @JsonProperty(JSON_PRIVATE_KEY)
     private String privateKey = null;
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        SSHCredentials sshCredentials = (SSHCredentials) o;
-        return Objects.equals(this.username, sshCredentials.username) &&
-               Objects.equals(this.keyPairName, sshCredentials.keyPairName) &&
-               Objects.equals(this.publicKey, sshCredentials.publicKey) &&
-               Objects.equals(this.privateKey, sshCredentials.privateKey);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(username, keyPairName, publicKey, privateKey);
-    }
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/Scope.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/Scope.java
@@ -27,9 +27,14 @@ import lombok.Setter;
 @Embeddable
 public class Scope implements Serializable {
 
-    @JsonProperty("prefix")
+    // JSON field constants
+    public static final String JSON_PREFIX = "prefix";
+
+    public static final String JSON_VALUE = "value";
+
+    @JsonProperty(JSON_PREFIX)
     private String prefix = null;
 
-    @JsonProperty("value")
+    @JsonProperty(JSON_VALUE)
     private String value = null;
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/Task.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/Task.java
@@ -32,7 +32,7 @@ import lombok.extern.log4j.Log4j2;
 @Setter
 @Entity
 @Table(name = "TASK")
-@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "taskId", scope = Task.class)
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = Deployment.JSON_TASK_ID, scope = Task.class)
 public class Task implements Serializable {
     @Id
     @Column(name = "TASK_ID")

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/TaskDefinition.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/TaskDefinition.java
@@ -23,12 +23,19 @@ import lombok.*;
 @ToString(callSuper = true)
 public class TaskDefinition implements Serializable {
 
-    @JsonProperty("name")
+    // JSON field constants
+    public static final String JSON_NAME = "name";
+
+    public static final String JSON_INSTALLATION = "installation";
+
+    public static final String JSON_PORTS = "ports";
+
+    @JsonProperty(JSON_NAME)
     private String name;
 
-    @JsonProperty("installation")
+    @JsonProperty(JSON_INSTALLATION)
     private AbstractInstallation installation;
 
-    @JsonProperty("ports")
+    @JsonProperty(JSON_PORTS)
     private List<AbstractPortDefinition> ports;
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/TaskReconfigurationDefinition.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/TaskReconfigurationDefinition.java
@@ -19,13 +19,20 @@ import lombok.NoArgsConstructor;
 @Data
 public class TaskReconfigurationDefinition implements Serializable {
 
-    @JsonProperty("task")
-    TaskDefinition task;
+    // JSON field constants
+    public static final String JSON_TASK = "task";
 
-    @JsonProperty("iaasNodeSelection")
-    IaasDefinition iaasNodeSelection;
+    public static final String JSON_IAAS_NODE_SELECTION = "iaasNodeSelection";
 
-    @JsonProperty("emsDeploymentDefinition")
+    public static final String JSON_EMS_DEPLOYMENT_DEFINITION = "emsDeploymentDefinition";
+
+    @JsonProperty(JSON_TASK)
+    private TaskDefinition task;
+
+    @JsonProperty(JSON_IAAS_NODE_SELECTION)
+    private IaasDefinition iaasNodeSelection;
+
+    @JsonProperty(JSON_EMS_DEPLOYMENT_DEFINITION)
     private EmsDeploymentDefinitionForNode emsDeploymentDefinition;
 
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/model/VaultKey.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/model/VaultKey.java
@@ -6,7 +6,6 @@
 package org.ow2.proactive.sal.model;
 
 import java.io.Serializable;
-import java.util.Objects;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -16,28 +15,18 @@ import javax.persistence.Table;
 import lombok.*;
 
 
+/**
+ * Represents a Vault Key entity.
+ */
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
+@EqualsAndHashCode
 @Entity
 @Table(name = "VAULT_KEY")
 public class VaultKey implements Serializable {
+
     @Id
     @Column(name = "KEY_NAME")
     private String keyName;
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-        VaultKey vaultKey = (VaultKey) o;
-        return Objects.equals(keyName, vaultKey.keyName);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(keyName);
-    }
 }

--- a/sal-common/src/main/java/org/ow2/proactive/sal/util/ModelUtils.java
+++ b/sal-common/src/main/java/org/ow2/proactive/sal/util/ModelUtils.java
@@ -1,0 +1,48 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+package org.ow2.proactive.sal.util;
+
+import java.util.Map;
+
+
+public class ModelUtils {
+
+    /**
+     * Builds a formatted string representation of an object, given its class name and fields.
+     * This method takes the class name and a map of field names and their respective values,
+     * and constructs a formatted string that represents the object in a human-readable way.
+     *
+     * @param className The name of the class to be included in the string representation.
+     * @param fields A map of field names (as keys) and field values (as values) to be included.
+     * @return A formatted string representing the class and its fields.
+     */
+    public static String buildToString(String className, Map<String, Object> fields) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ").append(className).append(" {\n");
+        fields.forEach((key, value) -> sb.append("    ")
+                                         .append(key)
+                                         .append(": ")
+                                         .append(toIndentedString(value))
+                                         .append("\n"));
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Indents multi-line strings and ensures proper formatting for null values.
+     * This method takes an object, converts it to a string, and ensures that each line in
+     * the string (if multi-line) is indented by 4 spaces. If the object is null, it returns "null".
+     *
+     * @param o The object to be converted into an indented string.
+     * @return The indented string representation of the object, or "null" if the object is null.
+     */
+    public static String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}

--- a/sal-service/src/main/java/org/ow2/proactive/sal/service/rest/ByonRest.java
+++ b/sal-service/src/main/java/org/ow2/proactive/sal/service/rest/ByonRest.java
@@ -26,7 +26,7 @@ import io.swagger.annotations.ApiParam;
 
 @RestController
 @RequestMapping(value = "/byon")
-@Api(description = "Operations on BYON", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
+@Api(tags = "Operations on BYON", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
 public class ByonRest {
 
     @Autowired

--- a/sal-service/src/main/java/org/ow2/proactive/sal/service/rest/CloudRest.java
+++ b/sal-service/src/main/java/org/ow2/proactive/sal/service/rest/CloudRest.java
@@ -24,7 +24,7 @@ import io.swagger.annotations.ApiParam;
 
 @RestController
 @RequestMapping(value = "/cloud")
-@Api(description = "Operations on clouds", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
+@Api(tags = "Cloud Operations", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
 public class CloudRest {
 
     @Autowired
@@ -115,9 +115,9 @@ public class CloudRest {
     @RequestParam(value = "cloudid")
     final Optional<String> cloudId) throws NotConnectedException {
         if (cloudId.isPresent()) {
-            return ResponseEntity.ok(cloudService.getCloudHardwares(sessionId, cloudId.get()));
+            return ResponseEntity.ok(cloudService.getCloudHardware(sessionId, cloudId.get()));
         } else {
-            return ResponseEntity.ok(cloudService.getAllCloudHardwares(sessionId));
+            return ResponseEntity.ok(cloudService.getAllCloudHardware(sessionId));
         }
     }
 

--- a/sal-service/src/main/java/org/ow2/proactive/sal/service/rest/ClusterRest.java
+++ b/sal-service/src/main/java/org/ow2/proactive/sal/service/rest/ClusterRest.java
@@ -25,7 +25,7 @@ import io.swagger.annotations.ApiParam;
 
 @RestController
 @RequestMapping(value = "/cluster")
-@Api(description = "Operations on Kubernetes cluster", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
+@Api(tags = "Operations on Kubernetes cluster", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
 public class ClusterRest {
 
     @Autowired
@@ -89,7 +89,7 @@ public class ClusterRest {
     @RequestHeader(value = "sessionid")
     final String sessionId, @PathVariable
     final String clusterName, @RequestBody
-    final List<Map<String, String>> nodesLabels) throws NotConnectedException, IOException {
+    final List<Map<String, String>> nodesLabels) throws NotConnectedException {
         return ResponseEntity.ok(clusterService.labelNodes(sessionId, clusterName, nodesLabels));
     }
 

--- a/sal-service/src/main/java/org/ow2/proactive/sal/service/rest/EdgeRest.java
+++ b/sal-service/src/main/java/org/ow2/proactive/sal/service/rest/EdgeRest.java
@@ -25,7 +25,7 @@ import io.swagger.annotations.ApiParam;
 
 @RestController
 @RequestMapping(value = "/edge")
-@Api(description = "Operations on Edge", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
+@Api(tags = "Operations on Edge", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
 public class EdgeRest {
 
     @Autowired

--- a/sal-service/src/main/java/org/ow2/proactive/sal/service/rest/JobRest.java
+++ b/sal-service/src/main/java/org/ow2/proactive/sal/service/rest/JobRest.java
@@ -30,7 +30,7 @@ import io.swagger.annotations.ApiParam;
 
 @RestController
 @RequestMapping(value = "/job")
-@Api(description = "Operations on jobs", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
+@Api(tags = "Operations on jobs", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
 public class JobRest {
 
     @Autowired

--- a/sal-service/src/main/java/org/ow2/proactive/sal/service/rest/MonitoringRest.java
+++ b/sal-service/src/main/java/org/ow2/proactive/sal/service/rest/MonitoringRest.java
@@ -24,7 +24,7 @@ import io.swagger.annotations.ApiParam;
 
 @RestController
 @RequestMapping(value = "/monitor")
-@Api(description = "Operations on EMS monitors", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
+@Api(tags = "Operations on EMS monitors", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
 public class MonitoringRest {
 
     @Autowired

--- a/sal-service/src/main/java/org/ow2/proactive/sal/service/rest/NodeCandidateRest.java
+++ b/sal-service/src/main/java/org/ow2/proactive/sal/service/rest/NodeCandidateRest.java
@@ -24,7 +24,7 @@ import io.swagger.annotations.ApiParam;
 
 @RestController
 @RequestMapping(value = "/nodecandidates")
-@Api(description = "Operations on node candidates", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
+@Api(tags = "Operations on node candidates", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
 public class NodeCandidateRest {
 
     @Autowired

--- a/sal-service/src/main/java/org/ow2/proactive/sal/service/rest/NodeRest.java
+++ b/sal-service/src/main/java/org/ow2/proactive/sal/service/rest/NodeRest.java
@@ -25,7 +25,7 @@ import io.swagger.annotations.ApiParam;
 
 @RestController
 @RequestMapping(value = "/node")
-@Api(description = "Operations on nodes", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
+@Api(tags = "Operations on nodes", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
 public class NodeRest {
 
     @Autowired

--- a/sal-service/src/main/java/org/ow2/proactive/sal/service/rest/PAGatewayRest.java
+++ b/sal-service/src/main/java/org/ow2/proactive/sal/service/rest/PAGatewayRest.java
@@ -31,7 +31,7 @@ import io.swagger.annotations.ApiParam;
 
 @RestController
 @RequestMapping(value = "/pagateway")
-@Api(description = "Operations on Proactive gateway", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
+@Api(tags = "Operations on Proactive gateway", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
 public class PAGatewayRest {
 
     @Autowired

--- a/sal-service/src/main/java/org/ow2/proactive/sal/service/rest/PersistenceRest.java
+++ b/sal-service/src/main/java/org/ow2/proactive/sal/service/rest/PersistenceRest.java
@@ -23,7 +23,7 @@ import io.swagger.annotations.ApiParam;
 
 @RestController
 @RequestMapping(value = "/persistence")
-@Api(description = "Operations to clean the cloud, clusters and SAL database", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
+@Api(tags = "Operations to clean the cloud, clusters and SAL database", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
 public class PersistenceRest {
 
     @Autowired

--- a/sal-service/src/main/java/org/ow2/proactive/sal/service/rest/ReconfigurationRest.java
+++ b/sal-service/src/main/java/org/ow2/proactive/sal/service/rest/ReconfigurationRest.java
@@ -21,7 +21,7 @@ import io.swagger.annotations.ApiParam;
 
 @RestController
 @RequestMapping(value = "/reconfigure")
-@Api(description = "Reconfiguration operations", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
+@Api(tags = "Reconfiguration operations", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
 public class ReconfigurationRest {
 
     @Autowired

--- a/sal-service/src/main/java/org/ow2/proactive/sal/service/rest/ScalingRest.java
+++ b/sal-service/src/main/java/org/ow2/proactive/sal/service/rest/ScalingRest.java
@@ -22,7 +22,7 @@ import io.swagger.annotations.ApiParam;
 
 @RestController
 @RequestMapping(value = "/scale")
-@Api(description = "Scaling operations", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
+@Api(tags = "Scaling operations", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
 public class ScalingRest {
 
     @Autowired

--- a/sal-service/src/main/java/org/ow2/proactive/sal/service/rest/VaultRest.java
+++ b/sal-service/src/main/java/org/ow2/proactive/sal/service/rest/VaultRest.java
@@ -26,7 +26,7 @@ import io.swagger.annotations.ApiParam;
 
 @RestController
 @RequestMapping(value = "/vault")
-@Api(description = "Operations on ProActive secrets vault", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
+@Api(tags = "Operations on ProActive secrets vault", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
 public class VaultRest {
     @Autowired
     private VaultService vaultService;

--- a/sal-service/src/main/java/org/ow2/proactive/sal/service/service/ByonService.java
+++ b/sal-service/src/main/java/org/ow2/proactive/sal/service/service/ByonService.java
@@ -173,7 +173,7 @@ public class ByonService {
             cloud.setCloudId(nodeSourceName);
             cloud.setNodeSourceNamePrefix(nodeSourceName);
             cloud.setCloudType(CloudType.BYON);
-            cloud.setCloudProviderName("BYON");
+            cloud.setCloudProvider(CloudProviderType.BYON);
             cloud.setSshCredentials(sshCred);
             cloud.addDeployment(newDeployment);
             newDeployment.setPaCloud(cloud);

--- a/sal-service/src/main/java/org/ow2/proactive/sal/service/service/CloudService.java
+++ b/sal-service/src/main/java/org/ow2/proactive/sal/service/service/CloudService.java
@@ -72,10 +72,10 @@ public class CloudService {
         List<String> savedCloudIds = new LinkedList<>();
         clouds.forEach(cloud -> {
             PACloud newCloud = new PACloud();
-            String nodeSourceNamePrefix = cloud.getCloudProviderName() + "-" + cloud.getCloudId();
+            String nodeSourceNamePrefix = cloud.getCloudProvider() + "-" + cloud.getCloudId();
             newCloud.setNodeSourceNamePrefix(nodeSourceNamePrefix);
             newCloud.setCloudId(cloud.getCloudId());
-            newCloud.setCloudProviderName(cloud.getCloudProviderName());
+            newCloud.setCloudProvider(cloud.getCloudProvider());
             newCloud.setCloudType(cloud.getCloudType());
             newCloud.setDeployedRegions(new HashMap<>());
             newCloud.setDeployedWhiteListedRegions(new HashMap<>());
@@ -99,13 +99,13 @@ public class CloudService {
             newCloud.setCredentials(credentials);
 
             String dummyInfraName = String.format(DUMMY_INFRA_NAME_TEMPLATE,
-                                                  newCloud.getCloudProviderName(),
+                                                  newCloud.getCloudProvider(),
                                                   newCloud.getCloudId());
             connectorIaasGateway.defineInfrastructure(dummyInfraName, newCloud, "");
             newCloud.setDummyInfrastructureName(dummyInfraName);
 
             repositoryService.savePACloud(newCloud);
-            LOGGER.debug("Cloud created: " + newCloud.toString());
+            LOGGER.debug("Cloud created: " + newCloud);
             savedCloudIds.add(newCloud.getCloudId());
         });
 
@@ -348,7 +348,7 @@ public class CloudService {
                 JSONArray imagesArray = connectorIaasGateway.getImages(paCloud.getDummyInfrastructureName());
 
                 String cloudIdOrEmpty;
-                if (paCloud.getCloudProviderName().equals("azure")) {
+                if (paCloud.getCloudProvider() == CloudProviderType.AZURE) {
                     cloudIdOrEmpty = "";
                 } else {
                     cloudIdOrEmpty = cloudId + "/";
@@ -387,35 +387,35 @@ public class CloudService {
     }
 
     /**
-     * This function returns the list of all available hardwares related to a registered cloud
+     * This function returns the list of all available hardware related to a registered cloud
      * @param sessionId A valid session id
      * @param cloudId A valid cloud identifier
-     * @return A list of available hardwares
+     * @return A list of available hardware
      */
-    public List<Hardware> getCloudHardwares(String sessionId, String cloudId) throws NotConnectedException {
-        LOGGER.warn("Feature not implemented yet. All hardwares will be returned.");
-        return getAllCloudHardwares(sessionId);
+    public List<Hardware> getCloudHardware(String sessionId, String cloudId) throws NotConnectedException {
+        LOGGER.warn("Feature not implemented yet. All hardware will be returned.");
+        return getAllCloudHardware(sessionId);
     }
 
     /**
-     * This function returns the list of all available hardwares
+     * This function returns the list of all available hardware
      * @param sessionId A valid session id
-     * @return A list of all available hardwares
+     * @return A list of all available hardware
      */
-    public List<Hardware> getAllCloudHardwares(String sessionId) throws NotConnectedException {
+    public List<Hardware> getAllCloudHardware(String sessionId) throws NotConnectedException {
         if (!paGatewayService.isConnectionActive(sessionId)) {
             throw new NotConnectedException();
         }
-        List<Hardware> allHardwares = repositoryService.listHardwares();
+        List<Hardware> allHardware = repositoryService.listHardwares();
 
-        return allHardwares.stream()
-                           .filter(hardware -> JCloudsInstancesUtils.isHandledHardwareInstanceType(repositoryService.findFirstNodeCandidateWithHardware(hardware)
-                                                                                                                    .getCloud()
-                                                                                                                    .getApi()
-                                                                                                                    .getProviderName(),
-                                                                                                   hardware.getName()) ||
-                                               WhiteListedInstanceTypesUtils.isHandledHardwareInstanceType(hardware.getName()))
-                           .collect(Collectors.toList());
+        return allHardware.stream()
+                          .filter(hardware -> JCloudsInstancesUtils.isHandledHardwareInstanceType(repositoryService.findFirstNodeCandidateWithHardware(hardware)
+                                                                                                                   .getCloud()
+                                                                                                                   .getApi()
+                                                                                                                   .getProviderName(),
+                                                                                                  hardware.getName()) ||
+                                              WhiteListedInstanceTypesUtils.isHandledHardwareInstanceType(hardware.getName()))
+                          .collect(Collectors.toList());
     }
 
     /**

--- a/sal-service/src/main/java/org/ow2/proactive/sal/service/service/EdgeService.java
+++ b/sal-service/src/main/java/org/ow2/proactive/sal/service/service/EdgeService.java
@@ -172,7 +172,7 @@ public class EdgeService {
             cloud.setCloudId(nodeSourceName);
             cloud.setNodeSourceNamePrefix(nodeSourceName);
             cloud.setCloudType(CloudType.EDGE);
-            cloud.setCloudProviderName("EDGE");
+            cloud.setCloudProvider(CloudProviderType.BYON);
             cloud.setSshCredentials(sshCred);
             cloud.addDeployment(newDeployment);
             newDeployment.setPaCloud(cloud);

--- a/sal-service/src/main/java/org/ow2/proactive/sal/service/service/MonitoringService.java
+++ b/sal-service/src/main/java/org/ow2/proactive/sal/service/service/MonitoringService.java
@@ -92,7 +92,8 @@ public class MonitoringService {
                                                             deployment.getDeploymentType().getName(),
                                                             deployment.getNode().getNodeCandidate(),
                                                             deployment.getNodeName(),
-                                                            EmsDeploymentRequest.TargetProvider.fromValue(cloud.getCloudProviderName()),
+                                                            EmsDeploymentRequest.TargetProvider.fromValue(cloud.getCloudProvider()
+                                                                                                               .toString()),
                                                             deployment.getTask()
                                                                       .getPortsToOpen()
                                                                       .stream()

--- a/sal-service/src/main/java/org/ow2/proactive/sal/service/service/NodeService.java
+++ b/sal-service/src/main/java/org/ow2/proactive/sal/service/service/NodeService.java
@@ -192,8 +192,8 @@ public class NodeService {
                                                                                   .getNodeCandidate()
                                                                                   .getHardware()
                                                                                   .getProviderId())) {
-            switch (cloud.getCloudProviderName()) {
-                case "aws-ec2":
+            switch (cloud.getCloudProvider()) {
+                case AWS_EC2:
                     filename = File.separator + "Define_NS_AWS_AutoScale.xml";
                     variables.put("aws_username", cloud.getCredentials().getUserName());
                     variables.put("aws_secret", cloud.getCredentials().getPrivateKey());
@@ -205,21 +205,21 @@ public class NodeService {
                     break;
                 default:
                     throw new IllegalArgumentException("Unhandled white listed instance type for cloud provider: " +
-                                                       cloud.getCloudProviderName());
+                                                       cloud.getCloudProvider());
             }
         } else {
             variables.put("NS_nVMs", "0");
             variables.put("image",
                           deployment.getNode().getNodeCandidate().getLocation().getName() + File.separator +
                                    deployment.getNode().getNodeCandidate().getImage().getProviderId());
-            switch (cloud.getCloudProviderName()) {
-                case "aws-ec2":
+            switch (cloud.getCloudProvider()) {
+                case AWS_EC2:
                     filename = File.separator + "Define_NS_AWS.xml";
                     variables.put("aws_username", cloud.getCredentials().getUserName());
                     variables.put("aws_secret", cloud.getCredentials().getPrivateKey());
                     variables.put("subnet", Optional.ofNullable(cloud.getSubnet()).orElse(""));
                     break;
-                case "openstack":
+                case OPENSTACK:
                     filename = File.separator + "Define_NS_OS.xml";
                     variables.put("os_endpoint", cloud.getEndpoint());
                     variables.put("os_scopePrefix", cloud.getScopePrefix());
@@ -231,7 +231,7 @@ public class NodeService {
                     variables.put("os_region", deployment.getNode().getNodeCandidate().getLocation().getName());
                     variables.put("os_networkId", cloud.getDefaultNetwork());
                     break;
-                case "azure":
+                case AZURE:
                     filename = File.separator + "Define_NS_Azure.xml";
                     variables.put("clientId", cloud.getCredentials().getUserName());
                     variables.put("secret", cloud.getCredentials().getPrivateKey());
@@ -252,7 +252,7 @@ public class NodeService {
                     variables.put("region", deployment.getNode().getNodeCandidate().getLocation().getName());
                     break;
                 default:
-                    throw new IllegalArgumentException("Unhandled cloud provider: " + cloud.getCloudProviderName());
+                    throw new IllegalArgumentException("Unhandled cloud provider: " + cloud.getCloudProvider());
             }
         }
         File fXmlFile = null;

--- a/sal-service/src/main/java/org/ow2/proactive/sal/service/service/TaskBuilder.java
+++ b/sal-service/src/main/java/org/ow2/proactive/sal/service/service/TaskBuilder.java
@@ -244,8 +244,8 @@ public class TaskBuilder {
     private String createIAASNodeConfigJson(Task task, Deployment deployment) {
         ObjectMapper mapper = new ObjectMapper();
         String imageId;
-        switch (deployment.getPaCloud().getCloudProviderName()) {
-            case "aws-ec2":
+        switch (deployment.getPaCloud().getCloudProvider()) {
+            case AWS_EC2:
                 if (WhiteListedInstanceTypesUtils.isHandledHardwareInstanceType(deployment.getNode()
                                                                                           .getNodeCandidate()
                                                                                           .getHardware()
@@ -256,10 +256,10 @@ public class TaskBuilder {
                               deployment.getNode().getNodeCandidate().getImage().getProviderId();
                 }
                 break;
-            case "openstack":
+            case OPENSTACK:
                 imageId = deployment.getNode().getNodeCandidate().getImage().getProviderId();
                 break;
-            case "azure":
+            case AZURE:
                 imageId = deployment.getNode().getNodeCandidate().getImage().getId();
                 break;
             default:
@@ -371,12 +371,12 @@ public class TaskBuilder {
     }
 
     private ScriptTask createInfraIAASTask(Task task, Deployment deployment, String taskNameSuffix, String nodeToken) {
-        switch (deployment.getPaCloud().getCloudProviderName()) {
-            case "aws-ec2":
+        switch (deployment.getPaCloud().getCloudProvider()) {
+            case AWS_EC2:
                 return createInfraIAASTaskForAWS(task, deployment, taskNameSuffix, nodeToken);
-            case "openstack":
+            case OPENSTACK:
                 return createInfraIAASTaskForOS(task, deployment, taskNameSuffix, nodeToken);
-            case "azure":
+            case AZURE:
                 return createInfraIAASTaskForAzure(task, deployment, taskNameSuffix, nodeToken);
             default:
                 return new ScriptTask();

--- a/sal-service/src/main/java/org/ow2/proactive/sal/service/service/TaskBuilder.java
+++ b/sal-service/src/main/java/org/ow2/proactive/sal/service/service/TaskBuilder.java
@@ -626,8 +626,11 @@ public class TaskBuilder {
 
     private Map<String, TaskVariable> createVariablesMapForIAASNodeRemoval(Deployment deployment) {
         Map<String, TaskVariable> variablesMap = new HashMap<>();
-        variablesMap.put("nodeName",
-                         new TaskVariable("nodeName", deployment.getNodeName(), "PA:NOT_EMPTY_STRING", false));
+        variablesMap.put(Deployment.JSON_NODE_NAME,
+                         new TaskVariable(Deployment.JSON_NODE_NAME,
+                                          deployment.getNodeName(),
+                                          "PA:NOT_EMPTY_STRING",
+                                          false));
         variablesMap.put("preempt", new TaskVariable("preempt", "true", "PA:Boolean", false));
         return (variablesMap);
     }
@@ -903,7 +906,7 @@ public class TaskBuilder {
     public ScriptTask createDrainNodeTask(String nodeName, String masterNodeToken) {
         ScriptTask drainNodeTask = PAFactory.createBashScriptTaskFromFile("Drain-Node", DRIAN_NODE_SCRIPT);
         Map<String, TaskVariable> variablesMap = new HashMap<>();
-        variablesMap.put("nodeName", new TaskVariable("nodeName", nodeName));
+        variablesMap.put(Deployment.JSON_NODE_NAME, new TaskVariable(Deployment.JSON_NODE_NAME, nodeName));
         drainNodeTask.setVariables(variablesMap);
         drainNodeTask.addGenericInformation("NODE_ACCESS_TOKEN", masterNodeToken);
         return drainNodeTask;

--- a/sal-service/src/main/java/org/ow2/proactive/sal/service/service/infrastructure/PAConnectorIaasGateway.java
+++ b/sal-service/src/main/java/org/ow2/proactive/sal/service/service/infrastructure/PAConnectorIaasGateway.java
@@ -116,7 +116,7 @@ public class PAConnectorIaasGateway {
     @SneakyThrows
     public void defineInfrastructure(String infrastructureName, PACloud cloud, String region) {
         Validate.notNull(infrastructureName, "infrastructureName must not be null");
-        Validate.notNull(cloud.getCloudProviderName(), "cloudProviderName must not be null");
+        Validate.notNull(cloud.getCloudProvider(), "cloudProviderName must not be null");
 
         URIBuilder uriBuilder = new URIBuilder(new URL(paURL).toURI());
         URI requestUri = uriBuilder.setPath(CONNECTOR_IAAS_PATH + "/infrastructures").build();
@@ -127,14 +127,14 @@ public class PAConnectorIaasGateway {
         connection.setDoOutput(true);
 
         String jsonOutputString;
-        switch (cloud.getCloudProviderName()) {
-            case "aws-ec2":
+        switch (cloud.getCloudProvider()) {
+            case AWS_EC2:
                 jsonOutputString = "{\"id\": \"" + infrastructureName + "\"," + "\"type\": \"" +
-                                   cloud.getCloudProviderName() + "\"," + "\"credentials\": {\"username\": \"" +
+                                   cloud.getCloudProvider() + "\"," + "\"credentials\": {\"username\": \"" +
                                    cloud.getCredentials().getUserName() + "\", \"password\": \"" +
                                    cloud.getCredentials().getPrivateKey() + "\"}}";
                 break;
-            case "openstack":
+            case OPENSTACK:
                 jsonOutputString = "{\"id\": \"" + infrastructureName + "\"," +
                                    "\"type\": \"openstack-nova\", \"endpoint\": \"" + cloud.getEndpoint() +
                                    "\", \"scope\":{\"prefix\": \"" + cloud.getScopePrefix() + "\", \"value\":\"" +
@@ -144,9 +144,9 @@ public class PAConnectorIaasGateway {
                                    cloud.getCredentials().getPrivateKey() + "\", \"domain\": \"" +
                                    cloud.getCredentials().getDomain() + "\"}, \"region\": \"" + region + "\"}";
                 break;
-            case "azure":
+            case AZURE:
                 jsonOutputString = "{\"id\": \"" + infrastructureName + "\"," + "\"type\": \"" +
-                                   cloud.getCloudProviderName() + "\"," + "\"credentials\": {\"username\": \"" +
+                                   cloud.getCloudProvider() + "\"," + "\"credentials\": {\"username\": \"" +
                                    cloud.getCredentials().getUserName() + "\", \"password\": \"" +
                                    cloud.getCredentials().getPrivateKey() + "\", \"domain\": \"" +
                                    cloud.getCredentials().getDomain() + "\", \"subscriptionId\": \"" +

--- a/sal-service/src/main/java/org/ow2/proactive/sal/service/util/JCloudsInstancesUtils.java
+++ b/sal-service/src/main/java/org/ow2/proactive/sal/service/util/JCloudsInstancesUtils.java
@@ -45,6 +45,7 @@ public class JCloudsInstancesUtils {
             return handledAWSInstanceTypes.contains(instanceType);
         }
         // TODO: To check if for other cloud providers all instance types are handled by JClouds
+        // not all instance types are handled (they can be excluded from findNodeCandidate by hardware/name attribute
         return true;
     }
 }


### PR DESCRIPTION
- removing the description field with the tags attribute in Rest Service @Api annotation as being depreciated
- exposing the JSON properties as constant and reusing them across the model 
- replacing manually written methods for equals and hash with Lombok annotations due to the same functionality
- introducing ModelUtils to have a custom toString function which is reused across the model

Nebulous scenarios used for validation:
- Add and removal of resources, Cluster deployment and reconfiguration for OS
- Add and removal of resources, Cluster deployment and reconfiguration for AWS
- Add and removal of resources, Cluster deployment for Azure
- Add and removal of resources, Cluster deployment for EDGE
